### PR TITLE
fix: ignore installer/prompts, restore templates/copilot-instructions.template.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ installer/smaqit-extensions
 # Installer temp directories (populated by make prepare)
 installer/agents/
 installer/skills/
+installer/prompts/
 
 # IDEs
 .vscode/

--- a/.smaqit/tasks/003_create_smaqit_read_pdf_skill.md
+++ b/.smaqit/tasks/003_create_smaqit_read_pdf_skill.md
@@ -1,0 +1,79 @@
+# Create smaqit.read-pdf Skill
+
+**Status:** Not Started  
+**Created:** 2026-05-02
+
+## Description
+
+Create a new `smaqit.read-pdf` skill for the smaqit-extensions repository. The skill enables agents to extract text from PDF files using `pdftotext`, then continue with the caller's original goal using the extracted content.
+
+This skill is a mid-request utility: when a user asks an agent to review, summarize, or analyze a PDF, the agent activates the skill, extracts the text to a sidecar file, reads it, and resumes the original task.
+
+**Trigger condition:** User references a `.pdf` file path and asks for any content-based action (review, summarize, analyze, benchmark extraction, etc.).
+
+## Directory Structure
+
+Per the [agentskills.io specification](https://agentskills.io/specification):
+
+```
+skills/smaqit.read-pdf/
+├── SKILL.md
+└── scripts/
+    └── extract.sh
+```
+
+No `references/` or `assets/` directories needed — instructions fit in `SKILL.md`.
+
+## Steps
+
+1. **Create `skills/smaqit.read-pdf/SKILL.md`** with:
+   - `name: smaqit.read-pdf`
+   - `description`: explains what the skill does and when to invoke it (PDF file referenced, content-based action requested)
+   - `compatibility`: `Requires poppler-utils (pdftotext). Install with: sudo apt install poppler-utils`
+   - `metadata.version: "0.1.0"`
+   - Body instructions (see Acceptance Criteria for required behavior)
+
+2. **Create `skills/smaqit.read-pdf/scripts/extract.sh`** — self-contained pdftotext wrapper:
+   - Accept PDF path as `$1`
+   - Check `command -v pdftotext`; exit 1 with clear install instruction if not found
+   - Run `pdftotext -layout "$1" "${1%.pdf}.extracted.txt"`
+   - Print sidecar path to stdout on success
+   - Handle edge cases: file not found, unreadable PDF, empty output
+
+3. **Make `extract.sh` executable** — `chmod +x skills/smaqit.read-pdf/scripts/extract.sh`
+
+4. **Write SKILL.md body** with agent instructions:
+   - Step 1: Run `scripts/extract.sh <pdf-path>` via terminal
+   - Step 2: Read the sidecar file path printed to stdout
+   - Step 3: Read sidecar content using `read_file`
+   - Step 4: Continue with the caller's original goal using the extracted text
+   - Include: sidecar naming convention, install instructions if tool missing
+
+5. **Run `make sync`** from the smaqit-extensions root to populate `.github/skills/smaqit.read-pdf/`
+
+6. **Verify sync** — confirm `.github/skills/smaqit.read-pdf/SKILL.md` and `.github/skills/smaqit.read-pdf/scripts/extract.sh` exist
+
+7. **Update PLANNING.md** — mark task 003 as Completed
+
+## Acceptance Criteria
+
+- [ ] `skills/smaqit.read-pdf/SKILL.md` exists with correct frontmatter: `name`, `description`, `compatibility`, `metadata.version: "0.1.0"`
+- [ ] `skills/smaqit.read-pdf/scripts/extract.sh` exists and is executable (`chmod +x`)
+- [ ] `extract.sh` checks for `pdftotext`; prints `sudo apt install poppler-utils` and exits 1 if missing
+- [ ] `extract.sh` writes sidecar as `<pdf-basename>.extracted.txt` next to the source PDF
+- [ ] `extract.sh` prints the sidecar path to stdout on success
+- [ ] SKILL.md body instructs the agent to run the script, read the sidecar, then continue with the caller's original goal
+- [ ] `make sync` run; `.github/skills/smaqit.read-pdf/` is populated and matches source
+- [ ] `skills-ref validate ./skills/smaqit.read-pdf` passes (if `skills-ref` is available)
+
+## Notes
+
+**Spec deviation:** The agentskills.io spec requires `name` to use only `a-z` and hyphens. All existing smaqit skills use dot notation (`smaqit.session-start`, etc.). Follow the existing project convention — use `smaqit.read-pdf` as the name.
+
+**Sidecar policy:** Written next to the source PDF by default (`<pdf-basename>.extracted.txt`). No `/tmp/` unless the user specifies otherwise.
+
+**Scope:** Single file only. Multi-PDF support is out of scope for v0.1.0.
+
+**`poppler-utils` status:** Not installed on the development WSL at time of task creation. Running `sudo apt install poppler-utils` is a prerequisite before the skill can be tested end-to-end.
+
+**Context for first-session pickup:** The immediate use case that prompted this task was reading `assets/docs/nvidia-dgx-spark-review-pros-cons-performance-benchmarks.pdf` in the daisy-tribe workspace, where the agent could not access the PDF content natively. This skill unblocks that and any future PDF-based workflows.

--- a/.smaqit/tasks/004_create_project_glossary_skill.md
+++ b/.smaqit/tasks/004_create_project_glossary_skill.md
@@ -1,0 +1,37 @@
+# Create smaqit.project-glossary Skill
+
+**Status:** Not Started
+**Created:** 2026-05-02
+
+## Description
+
+Create a new `smaqit.project-glossary` skill in `smaqit-extensions` that manages a per-project glossary file during agent sessions. The skill handles four operations via keyword triggers: listing all terms, fetching a specific term, updating (upsert) a term, and removing a term.
+
+The skill also requires a complementary update to `smaqit.session-start` so that the glossary is automatically loaded into agent context at session start — making terms available throughout the session without explicit invocation.
+
+## Design Decisions (confirmed)
+
+- **Storage path:** `.smaqit/glossary.md` — smaqit-managed, avoids collisions with manually-maintained `docs/glossary.md`
+- **Entry structure:** Term + Definition + Category (3-field markdown table, grouped by category)
+- **`update glossary` semantics:** Upsert — adds the term if absent, edits if it exists
+- **"Refreshed" mechanism:** `smaqit.session-start` loads the glossary into context at session start
+- **Description overloading:** Accepted — all four triggers listed explicitly in the skill description for reliable Copilot skill matching
+
+## Acceptance Criteria
+
+- [ ] `skills/smaqit.project-glossary/SKILL.md` created with correct frontmatter, description listing all four trigger phrases, and implementation steps for all four operations
+- [ ] Trigger phrases handled: `list glossary`, `fetch from glossary`, `update glossary`, `remove from glossary`
+- [ ] `update glossary` implements upsert semantics (adds new term or edits existing)
+- [ ] Glossary file format defined: `.smaqit/glossary.md` with markdown table grouped by category (Term | Definition | Category)
+- [ ] Skill handles missing glossary file gracefully (creates it on first write)
+- [ ] `skills/smaqit.session-start/SKILL.md` updated to include an optional glossary load step (read `.smaqit/glossary.md` if it exists and surface terms in context)
+- [ ] Both files synced to `.github/` via `make sync`
+- [ ] Versions bumped in frontmatter of all modified skills
+
+## Notes
+
+The skill description must enumerate all trigger phrases explicitly to compensate for Copilot's single-description matching limitation. Example description pattern:
+
+> "Manages a per-project glossary at `.smaqit/glossary.md`. Use for: list glossary, fetch from glossary, update glossary, remove from glossary."
+
+`smaqit.session-start` change is a soft dependency: glossary load step should be conditional (only runs if `.smaqit/glossary.md` exists) so existing projects without a glossary are unaffected.

--- a/.smaqit/tasks/PLANNING.md
+++ b/.smaqit/tasks/PLANNING.md
@@ -7,6 +7,8 @@ Central task tracking and planning for smaqit-extensions.
 | ID | Title | Status | Created |
 |----|-------|--------|---------|
 | 002 | Fix Changelog Extraction for Cumulative Releases | Not Started | 2026-02-13 |
+| 003 | Create smaqit.read-pdf Skill | Not Started | 2026-05-02 |
+| 004 | Create smaqit.project-glossary Skill | Not Started | 2026-05-02 |
 
 ## Completed Tasks
 

--- a/templates/copilot-instructions.template.md
+++ b/templates/copilot-instructions.template.md
@@ -1,0 +1,37 @@
+# Scaffolding
+
+This project uses **smaqit-extensions** scaffolding to support AI-assisted development workflows. The scaffolding files are **not part of this project's business domain**.
+
+When reasoning about business context, architecture, domain logic, or project conventions, **ignore the following smaqit scaffolding paths entirely**:
+
+- `.smaqit/` — smaqit state directory (task planning, session history, templates, user-testing artefacts)
+- `.github/agents/` — smaqit utility agents (release, user-testing)
+- `.github/skills/` — smaqit workflow skills (session, task, release, test)
+- `.github/workflows/` — smaqit CI workflows (e.g., `test-sync.yml`)
+- `installer/` — smaqit installer source code
+- `agents/` — smaqit agent source files (if present at repo root)
+- `skills/` — smaqit skill source files (if present at repo root)
+
+These files exist to support developer workflow automation and are maintained separately from the project's own code. They do not represent business requirements, domain models, or architectural decisions for this project.
+
+# Project
+
+## Project Name
+
+[TODO: add project name]
+
+## Purpose / Goal
+
+[TODO: describe the problem this project solves and its main objective]
+
+## Tech Stack
+
+[TODO: list primary languages, frameworks, libraries, and infrastructure — e.g., Go 1.22, PostgreSQL 16, React 18, deployed on AWS ECS]
+
+## Key Conventions
+
+[TODO: document coding style, branching strategy, naming rules, testing approach, and any other conventions the AI should follow — e.g., "use conventional commits", "all public functions must have doc comments", "tests live alongside source files"]
+
+## Domain Context
+
+[TODO: add any additional business domain knowledge, architectural constraints, or context the AI should be aware of]


### PR DESCRIPTION
## Changes

- Add `installer/prompts/` to `.gitignore` (deprecated, not tracked on main)
- Restore `templates/copilot-instructions.template.md` (part of project-init skill; was accidentally deleted during cleanup)

## Notes

- `installer/prompts/` was confirmed not in `origin/main` tree — stale local leftover from old builds
- `templates/copilot-instructions.template.md` restored from `installer/templates/copilot-instructions.template.md` (source of truth)