### PR TITLE
feat: add smaqit.parity-assess skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **smaqit.parity-assess** — added a structured parity assessment skill with Mermaid diagram guide, assessment template, and sync registration in the installer Makefile
+
 ## [1.1.4] - 2026-05-24
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ sync:
 	@echo "Syncing source files to .github/..."
 	@mkdir -p .github/agents .github/skills
 	@cp -f agents/*.md .github/agents/
-	@for skill in smaqit.session-start smaqit.session-finish smaqit.session-assess smaqit.session-title smaqit.session-recap smaqit.task-create smaqit.task-list smaqit.task-complete smaqit.task-start smaqit.test-start smaqit.project-init smaqit.project-glossary smaqit.release-analysis smaqit.release-approval smaqit.release-prepare-files smaqit.release-git-local smaqit.release-git-pr smaqit.utils.read-pdf smaqit.utils.triage-issues smaqit.project-research smaqit.project-recap smaqit.project-compendium; do \
+	@for skill in smaqit.session-start smaqit.session-finish smaqit.session-assess smaqit.session-title smaqit.session-recap smaqit.task-create smaqit.task-list smaqit.task-complete smaqit.task-start smaqit.test-start smaqit.project-init smaqit.project-glossary smaqit.release-analysis smaqit.release-approval smaqit.release-prepare-files smaqit.release-git-local smaqit.release-git-pr smaqit.utils.read-pdf smaqit.utils.triage-issues smaqit.project-research smaqit.project-recap smaqit.project-compendium smaqit.parity-assess; do \
 		mkdir -p .github/skills/$$skill; \
 		cp -f skills/$$skill/SKILL.md .github/skills/$$skill/; \
 		if [ -d skills/$$skill/references ]; then \

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Enhance your agentic development with streamlined session management, task track
 - **smaqit.project-recap** - Generate a live project dashboard from the current codebase state (`project.recap`, `project.recap --refresh`)
 - **smaqit.project-compendium** - Manage a live Q&A knowledge base (`list compendium`, `fetch from compendium`, `update compendium`, `remove from compendium`)
 
+#### Assessment
+- **smaqit.parity-assess** - Compare two systems and generate a structured parity assessment with Mermaid diagrams and an action roadmap (`parity.assess <name>`)
+
 #### Utilities
 - **smaqit.utils.read-pdf** - Extract text from a PDF file and continue with the caller's original goal
 - **smaqit.utils.triage-issues** - Search upstream GitHub repos for known issues before implementation begins (`task.triage [id]`)
@@ -63,7 +66,7 @@ curl -fsSL https://raw.githubusercontent.com/ruifrvaz/smaqit-extensions/main/ins
 
 The installer copies files to your project's `.github/` directory:
 - `agents/` - 3 utility agents (release local, release PR, user-testing)
-- `skills/` - 22 workflow skills (complete implementations)
+- `skills/` - 23 workflow skills (complete implementations)
 
 ## Usage
 

--- a/skills/smaqit.parity-assess/SKILL.md
+++ b/skills/smaqit.parity-assess/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: smaqit.parity-assess
+description: Produces a structured parity assessment comparing any two software systems — frameworks, libraries, platforms, or products. Identifies the current project from session context, studies the target system, checks domain compatibility, then outputs validated Mermaid diagrams and a written ASSESSMENT.md. Trigger phrase: `parity.assess <name>`.
+metadata:
+  version: "2.0.0"
+---
+
+# Parity Assess
+
+## Steps
+
+### Phase 0 — Identify the Current Project (Project A)
+
+Use session context first. If not available, read the project README and primary config/instructions file.
+
+Record:
+- **Domain** — the problem the project solves (2–3 words, e.g., "voice AI agent", "CI pipeline tool", "web framework")
+- **Core abstractions** — the 3–5 central types or concepts the system is built around
+- **Processing model** — how the system handles a primary operation (request → response, event → action, input → output)
+- **Technology** — language, runtime, key frameworks
+- **Key capabilities** — the top 5–7 features that define what the system does
+
+---
+
+### Phase 1 — Identify the Target System (Project B)
+
+Use `mcp_github_mcp_se_get_file_contents` for GitHub sources; use `fetch_webpage` for non-GitHub sources.
+
+Fetch in priority order — stop when the five targets below are known:
+
+1. Root `README.md`
+2. Root `AGENTS.md`, `CONTRIBUTING.md`, or equivalent overview doc
+3. Package-level `README.md` files (monorepos: iterate top-level packages)
+4. `docs/` directory listing → read architecture/design/overview docs (skip missing)
+5. Source directory listing for core packages → read the top 1–3 most architecturally significant files (≤20 KB each)
+
+> **Note:** `mcp_github_mcp_se_get_file_contents` may write large results to a file path. Read that path with `read_file` before using the content.
+
+Record the same five targets as Phase 0:
+- **Domain** — the problem Project B solves
+- **Core abstractions** — Project B's 3–5 central types or concepts
+- **Processing model** — how Project B handles its primary operation
+- **Technology** — language, runtime, key frameworks
+- **Key capabilities** — the top 5–7 features
+
+---
+
+### Phase 2 — Domain Compatibility Gate
+
+Compare the **Domain** of Project A and Project B.
+
+**Compatible domains** — proceed to Phase 3:
+- Same domain (e.g., both are agent orchestrators)
+- Adjacent domains with meaningful overlap (e.g., agent framework vs pipeline orchestrator)
+- One is a potential dependency or integration target for the other
+
+**Incompatible domains — full stop:**
+- Completely different problem spaces with no overlap (e.g., web application vs columnar database)
+- No plausible integration, adoption, or feature-parity path
+
+If incompatible: report to the user why the comparison is not meaningful and stop. Do not produce diagrams or an assessment.
+
+---
+
+### Phase 3 — Generate Diagrams
+
+Read `references/DIAGRAM_GUIDE.md` **before writing any Mermaid code**.
+
+Discover the output root: check if `docs/parity/` or `docs/orchestrator/parity/` exists and use the one that does; default to `docs/parity/` if neither exists.
+
+Set `OUTPUT_DIR = <parity-root>/<name>/`. If it already exists, confirm with the user before overwriting.
+
+Create the output directory by writing the first file into it. Produce up to four diagram files — skip any that are not applicable to the systems being compared:
+
+| # | Filename | Diagram type | Content |
+|---|----------|-------------|---------|
+| 1 | `01-<name>-architecture.md` | `flowchart TD` | Project B's component/package structure and data flow |
+| 2 | `02-<name>-core-flow.md` | `sequenceDiagram` | Project B's primary processing cycle (request, event, turn — whatever applies) |
+| 3 | `03-<name>-state-model.md` | `flowchart TD` | Project B's state/data persistence model (omit if stateless or N/A) |
+| 4 | `04-<name>-vs-<project-a>-feature-gap.md` | `flowchart LR` | Side-by-side feature comparison, colour-coded by parity status |
+
+**After writing each diagram file, run `mermaid-diagram-validator`. Do not proceed until the current diagram validates.**
+
+---
+
+### Phase 4 — Write Assessment
+
+Read `references/ASSESSMENT_TEMPLATE.md` before writing.
+
+Write `<OUTPUT_DIR>/ASSESSMENT.md` with all five mandatory sections:
+
+1. **What `<name>` is** — factual description, purpose, language/runtime, key differentiators
+2. **Structural mapping** — table pairing each Project B concept with Project A's equivalent
+3. **Relationship options** — concrete options for how the two systems could relate (adopt, integrate, reference, replace, ignore)
+4. **Recommendation** — one clear choice with numbered rationale
+5. **Parity roadmap** — ordered table of features/gaps worth closing
+
+---
+
+### Phase 5 — Register
+
+Look for a parity index file (e.g., `<parity-root>/README.md`). If it exists, add a row for the new assessment. If it does not exist, skip this step.
+
+---
+
+### Phase 6 — Report
+
+Return to user:
+- Paths of all files created
+- One-sentence recommendation from the assessment
+- Any items marked `[?]` in outputs
+
+---
+
+## Completion Criteria
+
+- [ ] Project A domain and capabilities recorded from session context or workspace
+- [ ] Project B domain and capabilities recorded from source
+- [ ] Domain compatibility confirmed before proceeding
+- [ ] All applicable diagram files created and validated
+- [ ] `ASSESSMENT.md` present with all five mandatory sections
+- [ ] Parity index updated (if it exists)
+- [ ] No `[?]` items left unacknowledged in the report
+
+---
+
+## Failure Handling
+
+| Situation | Action |
+|-----------|--------|
+| No URL provided | Ask for it before Phase 1 |
+| Source not on GitHub | Use `fetch_webpage`; mark gaps with `[?]` |
+| Source private / inaccessible | Proceed with public docs; mark unknowns `[?]` |
+| Domains are incompatible | Report and stop — do not produce output |
+| Output directory already exists | Confirm with user before overwriting |
+| Mermaid validation fails | Fix in memory; re-validate before writing to disk |
+| System has no state model | Omit diagram 3; note it in the assessment |
+| Large file response written to path | Read that path with `read_file` before using content |
+
+---
+
+## References
+
+Read when the condition is met:
+
+- `references/DIAGRAM_GUIDE.md` — **always**, at the start of Phase 3
+- `references/ASSESSMENT_TEMPLATE.md` — **always**, at the start of Phase 4

--- a/skills/smaqit.parity-assess/references/ASSESSMENT_TEMPLATE.md
+++ b/skills/smaqit.parity-assess/references/ASSESSMENT_TEMPLATE.md
@@ -1,0 +1,144 @@
+# Assessment Template — smaqit.parity-assess
+
+**Version:** 2.0.0  
+**Read before:** Phase 4 of every parity assessment.
+
+Fill in every section. Replace all `<placeholders>` with content discovered in Phases 0–1. Mark genuinely unknown values with `[?]` and a brief inline note.
+
+**Project A** = the current project (host).  
+**Project B** = the target system being assessed (`<name>`).
+
+---
+
+```markdown
+# <Name> Parity Assessment
+
+Source: <URL>  
+Studied: <YYYY-MM-DD> · <commit SHA or version>
+
+## What `<name>` is
+
+[2–4 sentences. Cover: purpose, primary use-case, language/runtime, and 2–3 key differentiating features. Factual — do not compare to Project A yet.]
+
+Key properties:
+- **<Property 1>** — <value>
+- **<Property 2>** — <value>
+- **<Property 3>** — <value>
+
+---
+
+## Structural Mapping
+
+[Pair each discovered concept in Project B with its counterpart in Project A.  
+Mapping quality: **1:1** (direct equivalent) · **partial** (similar but different scope) · **absent** (Project A has no equivalent) · **a-only** (Project A has this; Project B does not).
+
+Derive rows from the features discovered in Phases 0 and 1 — do not copy rows from this template verbatim. Add or remove rows as needed.]
+
+| Concept | Project B implementation | Project A equivalent | Mapping quality |
+|---------|------------------------|--------------------|-----------------|
+| [Core abstraction / carrier] | `<type or class>` | `<type or class>` | <quality> |
+| [Primary processing unit] | `<function / component>` | `<function / component>` | <quality> |
+| [Extension / plugin model] | `<API / interface>` | `<API / interface>` | <quality> |
+| [State / persistence model] | `<format / class>` | `<format / class or "none">` | <quality> |
+| [Configuration / registration] | `<mechanism>` | `<mechanism>` | <quality> |
+| [Feature unique to B] | `<description>` | None | absent |
+| [Feature unique to A] | None | `<description>` | a-only |
+
+---
+
+## Relationship Options
+
+[Enumerate the realistic options for how Project A could relate to Project B. Include only options that are genuinely applicable. Common options are listed below — adapt, add, or remove as needed.]
+
+### Option A — Direct integration (subprocess / SDK / RPC)
+
+[Describe: how Project B would be embedded or called from Project A. What the interface looks like. What translation is needed.]
+
+**Pros:**
+- <pro>
+
+**Cons:**
+- <con>
+
+**Verdict:** [1–2 sentences. State viability and time horizon.]
+
+---
+
+### Option B — Feature parity (implement equivalent capabilities natively)
+
+[Describe: which Project B features map to which Project A tasks or components. Reference specific source files as design specs.]
+
+**Pros:**
+- <pro>
+
+**Cons:**
+- <con>
+
+**Verdict:** [1–2 sentences.]
+
+---
+
+### Option C — Use as design reference only
+
+[Describe: treat Project B's codebase as a specification; implement natively without a runtime dependency.]
+
+**Verdict:** [1–2 sentences.]
+
+---
+
+### Option D — Adopt / replace *(include only if applicable)*
+
+[Describe: replace part of Project A with Project B, or adopt Project B as the primary implementation.]
+
+**Verdict:** [1–2 sentences.]
+
+---
+
+## Recommendation
+
+**Option [letter] — [option name]**
+
+[1 sentence stating the recommendation.]
+
+Rationale:
+
+1. [Architectural fit — why this option aligns with Project A's structure]
+2. [Delivery path — what this option enables or unblocks]
+3. [Risk or constraint — security, deployment, maintenance boundary]
+4. [Project A advantage — what Project A has that justifies not simply adopting B]
+5. [Optional: maintenance cost or long-term trajectory]
+
+---
+
+## Parity Roadmap
+
+[Ordered by delivery priority. Include only features worth closing. Skip cosmetic or power-user-only differences.]
+
+| Priority | Feature | Project B reference file | Project A task / component | Status | Benefit |
+|----------|---------|------------------------|--------------------------|--------|---------|
+| 1 | <feature> | `<path/to/file>` | <task or component> | <status> | <benefit> |
+| 2 | <feature> | `<path/to/file>` | <task or component> | <status> | <benefit> |
+| 3 | <feature> | `<path/to/file>` | unplanned | — | <benefit> |
+
+---
+
+## Project A Advantages
+
+[Capabilities Project A has that Project B lacks. These are the counter-arguments to simple adoption. Include only real, demonstrable advantages — not aspirational ones.]
+
+| Project A capability | Project B equivalent |
+|---------------------|---------------------|
+| <capability> | None / <equivalent> |
+| <capability> | None / <equivalent> |
+```
+
+---
+
+## Writing Rules
+
+1. **Structural mapping rows come from discovery, not from this template.** Read the systems first; then populate the table with what you found.
+2. **Include only the relationship options that are genuinely applicable.** Do not add option D if it is not realistic.
+3. **The recommendation must be unambiguous.** Do not say "it depends" without immediately resolving the dependency.
+4. **The roadmap is ordered by delivery priority**, not by feature completeness or importance in Project B.
+5. **Project A advantages are mandatory.** If Project A has no meaningful advantages over Project B, state that explicitly — it changes the recommendation.
+6. **Mark genuinely unknown fields with `[?]`** and a note. Do not guess.

--- a/skills/smaqit.parity-assess/references/DIAGRAM_GUIDE.md
+++ b/skills/smaqit.parity-assess/references/DIAGRAM_GUIDE.md
@@ -1,0 +1,206 @@
+# Diagram Guide — smaqit.parity-assess
+
+**Version:** 2.0.0  
+**Read before:** every Phase 3 diagram in a parity assessment.
+
+This guide defines which diagram type maps to each output slot, the semantic colour palette, structural rules, and Mermaid syntax pitfalls to avoid. Templates here are structural skeletons — replace every `[slot]` with content derived from the systems being compared.
+
+---
+
+## Colour Palette
+
+Colours are semantic — they communicate parity status, not domain. Apply them consistently in every diagram.
+
+| Meaning | Fill | Text | When to apply |
+|---------|------|------|---------------|
+| Feature present / equivalent | `#2d7a4f` | `#fff` | Both systems have this; or it exists in the system being diagrammed |
+| Feature partial / degraded | `#c87941` | `#fff` | Present but limited, sequential-only, or incomplete |
+| Feature absent / gap | `#8b0000` | `#fff` | Missing in one system; a parity gap |
+| State / persistence layer | `#6a5acd` | `#fff` | Any node representing stored or managed state |
+| Extension / plugin layer | `#c87941` | `#fff` | Any node representing extensibility or plugin surfaces |
+| Neutral / infrastructure | `#444` | `#fff` | Headers, entry points, config, build artifacts |
+
+Apply via `style NodeId fill:#hexcode,color:#fff`.
+
+**In architecture and flow diagrams (diagrams 1–3):** colour nodes by their role in the system (state = purple, neutral entry = dark grey, etc.).  
+**In the feature gap diagram (diagram 4):** colour nodes by parity status (green = present, orange = partial, red = absent).
+
+---
+
+## Diagram 1 — Architecture (`flowchart TD`)
+
+**Purpose:** Show Project B's structural layers — what components/packages/modules exist and how data flows through them top-to-bottom.
+
+**Structural skeleton:**
+
+```mermaid
+flowchart TD
+    ENTRY["[Entry point or CLI\npackage / binary name]"]
+    CORE["[Core processing layer\nresponsibility of this layer]"]
+    LAYER_A["[Sub-layer A\nresponsibility]"]
+    LAYER_B["[Sub-layer B\nresponsibility]"]
+    EXT["[Extension / plugin surface\nhow the system is extended]"]
+    PERSIST["[State / persistence layer\nhow data is stored or retained]"]
+
+    ENTRY --> CORE
+    CORE --> LAYER_A
+    CORE --> LAYER_B
+    CORE --> EXT
+    CORE --> PERSIST
+
+    style ENTRY fill:#444,color:#fff
+    style PERSIST fill:#6a5acd,color:#fff
+    style EXT fill:#c87941,color:#fff
+```
+
+**Rules:**
+- Derive layers from what the system *actually is* — not from a template. A web framework has routes/middleware/handlers; a build tool has tasks/targets/runners; an agent has a loop/tools/memory.
+- One node per major conceptual layer; do not map to source files 1:1.
+- Multi-line labels: use `\n` inside `["..."]`; wrap at ~40 characters.
+- Maximum 12 nodes — aggregate small helpers into their parent layer.
+- Arrows follow data/control flow, not import dependency.
+
+---
+
+## Diagram 2 — Core Processing Flow (`sequenceDiagram`)
+
+**Purpose:** Show how Project B handles one complete primary operation — from the triggering input to the final output. The nature of this operation depends on the system:
+
+| System type | Primary operation |
+|------------|------------------|
+| Agent / assistant | User prompt → LLM turn(s) → response |
+| Web framework | HTTP request → middleware chain → response |
+| Build tool | Command invocation → task graph execution → artifacts |
+| Data pipeline | Ingestion event → transform stages → sink |
+| Library / SDK | API call → internal computation → return value |
+
+**Structural skeleton:**
+
+```mermaid
+sequenceDiagram
+    participant CALLER as [Caller / Client]
+    participant CORE as [Core System]
+    participant WORKER as [Worker / Sub-system]
+
+    CALLER->>CORE: [primary input / trigger]
+    CORE->>CORE: [initialisation or routing]
+    loop [main processing cycle]
+        CORE->>WORKER: [delegate unit of work]
+        WORKER-->>CORE: [result]
+        CORE->>CORE: [decision: continue or stop]
+    end
+    CORE->>CALLER: [final output]
+```
+
+**Rules:**
+- Maximum 4 participants — combine if needed.
+- Use `loop` for any cycle; use `alt / else` for branches.
+- Add `note over Participant: text` for non-obvious state transitions.
+- Omit `activate/deactivate` — it adds noise without clarity.
+- `note over A,B:` (two participants) uses comma, not a range.
+- If there is no meaningful processing cycle (e.g., a pure library), draw a flat call-and-return sequence instead.
+
+---
+
+## Diagram 3 — State / Data Model (`flowchart TD`)
+
+**Purpose:** Show how Project B structures and retains state — sessions, schemas, trees, stores, or event logs.
+
+**Use this diagram only if Project B has a non-trivial state or data model** (persistent storage, branching, schemas, versioning, event sourcing).
+
+**Omit this diagram if:**
+- The system is stateless across invocations
+- State is trivially a flat key-value store with no interesting structure
+- Document the omission in the ASSESSMENT instead
+
+**Structural skeleton:**
+
+```mermaid
+flowchart TD
+    ROOT["[Top-level state object / store header]"]
+    RECORD_A["[Primary record type A]"]
+    RECORD_B["[Primary record type B]"]
+    DERIVED["[Derived or computed state]"]
+    ARCHIVE["[Historical / compacted state\nor persisted snapshot]"]
+
+    ROOT --> RECORD_A
+    ROOT --> RECORD_B
+    RECORD_B -->|transformation| DERIVED
+    RECORD_A -->|archived| ARCHIVE
+
+    style ROOT fill:#444,color:#fff
+    style ARCHIVE fill:#6a5acd,color:#fff
+```
+
+**Rules:**
+- Show the *structure* of the data model, not a flowchart of operations.
+- Use distinct colours only for structurally distinct layers (e.g., live vs. archived state).
+- If the model has tree or graph structure (e.g., parent/child entries), show that topology explicitly.
+
+---
+
+## Diagram 4 — Feature Gap (`flowchart LR`)
+
+**Purpose:** Side-by-side comparison of Project B vs Project A, colour-coded by parity status. This is the primary decision-support diagram.
+
+**Structural skeleton:**
+
+```mermaid
+flowchart LR
+    subgraph B["[Project B name]"]
+        B1["[Feature or capability 1]"]
+        B2["[Feature or capability 2]"]
+        B3["[Feature or capability 3]"]
+        B4["[Feature or capability 4]"]
+        B5["[Feature or capability 5]"]
+    end
+
+    subgraph A["[Project A name]"]
+        A1["[Equivalent / counterpart ✅]"]
+        A2["[Partial equivalent 🟡]"]
+        A3["[Absent 🔴]"]
+        A4["[Absent 🔴]"]
+        A5["[Project A only — not in B ✅]"]
+    end
+
+    B1 -.->|overlap| A1
+    B2 -.->|partial| A2
+    B3 -.->|gap| A3
+    B4 -.->|gap| A4
+    B5 -.->|a-only| A5
+
+    style B1 fill:#2d7a4f,color:#fff
+    style B2 fill:#c87941,color:#fff
+    style B3 fill:#8b0000,color:#fff
+    style B4 fill:#8b0000,color:#fff
+    style B5 fill:#2d7a4f,color:#fff
+
+    style A1 fill:#2d7a4f,color:#fff
+    style A2 fill:#c87941,color:#fff
+    style A3 fill:#8b0000,color:#fff
+    style A4 fill:#8b0000,color:#fff
+    style A5 fill:#2d7a4f,color:#fff
+```
+
+**Rules:**
+- Derive features from what was discovered in Phases 0 and 1 — not from this template.
+- Apply **identical colours to matching rows** on both sides — the visual alignment is the primary signal.
+- Status emoji in node labels supplements colour: ✅ present · 🟡 partial · 🔴 absent.
+- Edge labels: `overlap` (both have it) · `partial` (similar but degraded) · `gap` (absent in A) · `a-only` (Project A has it, B does not) · `different` (exists in both, incompatible).
+- Include `a-only` rows if Project A has meaningful capabilities the reference system lacks — these justify why simple adoption isn't always the right answer.
+- Maximum 6–8 rows per subgraph — aggregate minor features.
+
+---
+
+## Common Mermaid Pitfalls
+
+| Issue | Rule |
+|-------|------|
+| Parentheses in node label | Always quote: `A["label (with parens)"]` |
+| Colon in node label | Always quote: `A["key: value"]` |
+| Arrow bracket in node label | Always quote: `A["type<T>"]` |
+| Multi-line label | Use `\n` inside `["..."]` |
+| `note over` two participants | Comma syntax: `note over A,B: text` |
+| Node referenced outside its subgraph | Define the node inside the subgraph first |
+| Edge label with spaces | Quote: `A -->|"label text"| B` |
+| Style declarations | Place all `style` lines at the end of the diagram |


### PR DESCRIPTION
Adds the smaqit.parity-assess skill, its diagram guide, and assessment template. Also updates the README skill inventory, changelog, and Makefile sync list so the skill is installable and visible in the repo tooling.