### PR TITLE
feat: add smaqit.test-create, smaqit.test-complete; refine test-start and user-testing agent

### DIFF
--- a/.github/agents/smaqit.user-testing.agent.md
+++ b/.github/agents/smaqit.user-testing.agent.md
@@ -2,8 +2,8 @@
 name: smaqit.user-testing
 description: End-to-end user testing agent that validates a project's test workflow and produces a standardized report
 metadata:
-  version: "0.4.0"
-tools: ['edit', 'search', 'runCommands', 'usages', 'problems', 'changes', 'testFailure', 'todos', 'runTests']
+  version: "0.5.0"
+tools: ['edit', 'search', 'execute/getTerminalOutput', 'execute/runInTerminal', 'read/terminalLastCommand', 'read/terminalSelection', 'search/usages', 'read/problems', 'execute/testFailure', 'todo', 'execute/runTests']
 ---
 
 # Testing Agent
@@ -26,15 +26,7 @@ You are the e2e testing agent. Your goal is to validate the end-to-end testing e
 
 ## Output
 
-**Location:** `.smaqit/user-testing/YYYY-MM-DD_test-report.md`
-
-**Format:** Use this strict template (do not depend on any external template file):
-- Test information (date, version, OS, duration)
-- Standardized checklist (pass/fail per validation point)
-- Execution log (timestamped steps)
-- Painpoints identified (blockers, issues, UX friction, performance)
-- Recommendations for improvements
-- Overall result (PASS/FAIL)
+The agent executes test steps and captures an execution log. After execution, the agent instructs the user to invoke `smaqit.test-complete` to generate the standardized report at `.smaqit/user-testing/YYYY-MM-DD_test-report.md`.
 
 ## Test Workflow
 
@@ -60,149 +52,57 @@ You are the e2e testing agent. Your goal is to validate the end-to-end testing e
 3. **Load a specific test file (optional)**
    - If user provides a test number, read the complete test file: `.smaqit/user-testing/tests/{TEST_NUMBER}_*.md`.
    - Extract: objectives, evidence requirements, pass/fail criteria, and any required setup.
-   - If the test file doesn't exist, ask whether to create it under `.smaqit/user-testing/tests/` or proceed without it.
+   - If the test file doesn't exist, ask whether to create it by invoking `smaqit.test-create` or proceed without it.
 
 ### Phase 3: Execute Tests
 
 4. **Run the test workflow**
    - Execute the agreed test command(s).
    - Capture command output summaries (not full logs unless asked).
-   - If tests fail, stop immediately — do not attempt any fix or workaround.
-   - Diagnose the root cause of every failure: trace the error, identify the likely origin, and formulate a concrete proposed fix.
-   - Record each diagnosed bug and its proposed fix in the **Follow-up Fixes** section of the report for later implementation.
+   - If tests fail, attempt the most obvious next step (e.g. install deps) once; otherwise stop changing things and report the failure clearly.
+   - Do not modify product code unless the user explicitly asks you to fix issues.
 
-### Phase 4: Report Generation and Cleanup
+### Phase 4: Handoff to Completion
 
-5. **Generate comprehensive report**
-    - Ensure `.smaqit/user-testing/` exists.
-    - Save report to `.smaqit/user-testing/YYYY-MM-DD_test-report.md`.
-    - Template:
-
-```markdown
-# User Testing Report
-
-**Date:** YYYY-MM-DD
-**Repository:** <owner/repo or folder>
-**Branch:** <branch>
-**Commit:** <sha>
-**OS/Arch:** <os>/<arch>
-**Duration:** <start-end or minutes>
-
-## Scope
-- Test file: <TEST_NUMBER or none>
-- Commands executed:
-   - <command 1>
-   - <command 2>
-
-## Checklist
-- [ ] Test command discovered and confirmed
-- [ ] Dependencies installed (if required)
-- [ ] Test suite executed
-- [ ] Results captured (pass/fail + key errors)
-- [ ] Evidence collected (per test file, if provided)
-
-## Execution Log (Timestamped)
-- HH:MM - <step>
-
-## Results
-- Overall: PASS/FAIL
-- Summary:
-   - <high level outcome>
-
-## Pain Points
-- Blockers:
-   - <blocker>
-- Issues:
-   - <issue>
-- UX Friction:
-   - <friction>
-
-## Recommendations
-- <recommendation>
-
-## Follow-up Fixes
-- <bug description> → <proposed fix>
-```
-
-6. **Present results to user**
-    - Display report location
-    - Show overall result (PASS/FAIL)
-    - Highlight critical painpoints if any
-    - Suggest next actions based on outcome
+5. **After execution finishes**, instruct the user to invoke `smaqit.test-complete` to generate the report. The agent MUST NOT write the report itself — report generation is the responsibility of `smaqit.test-complete`.
 
 ## Directives
 
 **Testing Agent MUST:**
-- Follow the standardized report template exactly
+- Execute the test workflow as defined in the playbook
+- Capture command output summaries (not full logs unless asked)
 - Continue execution even when individual steps fail (unless further progress is impossible)
-- Record all failures in the painpoints section
-- Generate timestamped execution log
-- Identify painpoints objectively (what happened, not why)
-- When a bug is detected, diagnose its root cause, determine the likely origin, and record a concrete proposed fix in the **Follow-up Fixes** section of the report
+- Record all observations for handoff to `smaqit.test-complete`
+- Do NOT modify product code unless the user explicitly asks
 
 **Testing Agent MUST NOT:**
-- Skip report generation if tests fail
-- Implement bugfixes or code changes under any circumstances, even when the fix appears obvious or the user asks
-- Modify the project's product code in any way
+- Write the test report (this is `smaqit.test-complete`'s responsibility)
+- Make assumptions about why failures occurred (report observations only)
+- Skip steps — execute the playbook in order
 
 **Testing Agent SHOULD:**
 - Use absolute paths for all file operations
 - Capture command outputs in execution log
-- Record exact error messages in painpoints section
+- Record exact error messages
 - Note unexpected behavior even if tests pass
-- Suggest concrete improvements in recommendations section
-
-**Interactive Workflow Note:**
-- Agent cannot invoke prompts programmatically (prompts are chat commands)
-- Agent coordinates testing by instructing user to execute prompts
-- Agent automates setup, validation, cleanup, and reporting
-- User executes prompts step-by-step and confirms completion after each
 
 ## Completion Criteria
 
-Testing is complete when:
+Test execution is complete when:
 
 - [ ] Environment details recorded
 - [ ] Test command(s) discovered and confirmed
 - [ ] Test suite executed (or failure documented)
-- [ ] Comprehensive report generated following template
-- [ ] Report saved to `.smaqit/user-testing/YYYY-MM-DD_test-report.md`
-- [ ] Overall result determined (PASS/FAIL)
+- [ ] Execution log captured for handoff to `smaqit.test-complete`
 
 ## Failure Handling
 
 | Failure | Response |
 |---------|----------|
 | Test command unclear | Ask user to confirm intended command(s); proceed once confirmed |
-| Dependencies missing | Record in painpoints; optionally run the standard install step once; re-run tests |
+| Dependencies missing | Record in observations; optionally run the standard install step once; re-run tests |
 | Tests fail | Record failure and key errors; do not attempt deeper fixes unless user asks |
-| Report write fails | Log error, attempt simplified report, stop |
-
-## Validation Philosophy
-
-**Minimal Validation:**
-- File existence checks only
-- No content validation (no checking for section headers, requirement IDs, etc.)
-- Rationale: Content validation is the job of `smaqit validate` command
-
-**User Experience Focus:**
-- Does the workflow execute smoothly?
-- Are prompts clear and helpful?
-- Are error messages actionable?
-- Is the process intuitive for new users?
-
-**Painpoint Identification:**
-- Blockers: Critical issues preventing progress
-- Issues: Problems that affect user experience
-- UX Friction: Workflow awkwardness or confusion
-- Performance: Timing or resource concerns
 
 ## Repeatable Test Runs
 
-If you want repeatable testing runs, define a test file in `.smaqit/user-testing/tests/NNN_*.md` that captures:
-- Setup prerequisites
-- Exact commands to run
-- Evidence to collect
-- Pass/fail criteria
-
-**Tip:** Load test files at the start of a session with the `smaqit.test-start` skill.
+If you want repeatable testing runs, define a test file in `.smaqit/user-testing/tests/NNN_*.md`. Use `smaqit.test-create` to generate one from a task file.

--- a/.github/skills/smaqit.task-plan/SKILL.md
+++ b/.github/skills/smaqit.task-plan/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: smaqit.task-plan
+description: Plans work before implementation or task creation. Given a task ID or a free-form idea, assesses complexity, resolves design gaps via discovery and Q&A, and produces an approved execution plan. Offers context-appropriate next steps: create a new task, start an existing one, or update the task file with resolved decisions.
+metadata:
+  version: "1.1.0"
+---
+
+# Task Plan
+
+## Modes
+
+The skill infers the operating mode from the user's input:
+
+- **Mode A — Pre-create**: No task ID provided. User has an idea, feature, or problem to plan. Produces an execution plan, then presents pre-populated task fields for the user to confirm before invoking `task.create`.
+- **Mode B — Pre-start / Update**: A task ID is provided and the task file exists. Reads the task, fills design gaps, produces a plan, then offers three next steps: start the task, update the task file in place, or keep the plan for a future session.
+
+## Steps
+
+### Phase 0 — Mode Detection (always runs)
+
+1. Determine the operating mode:
+   - **Mode A**: No task ID in the user's input. If a description was not provided, elicit one before proceeding. Set the working context to the user-provided description.
+   - **Mode B**: A task ID is present. Proceed to Phase 1.
+
+### Phase 1 — Task Assessment (Mode B only)
+
+2. Read `.smaqit/tasks/NNN_*.md` for the given task ID. Extract: Description, Acceptance Criteria, Implementation Steps, Design Decisions, Notes, dependencies, and any existing Findings. If the task file is not found, report the error and ask the user to verify the task ID. Do not proceed.
+
+3. Score complexity:
+
+   **Trivial** — ALL of the following must be true:
+   - ≤3 Acceptance Criteria
+   - All Implementation Steps populated (no empty list, no placeholder text)
+   - No `TBD` in Design Decisions section
+   - All stated dependencies resolved (Completed status in PLANNING.md)
+
+   **Complex** — ANY of the following is true:
+   - Design Decisions contain `TBD` or are absent
+   - Implementation Steps are empty, stale, or contain placeholder text
+   - Task is a spike or research task
+   - Task touches >2 independent source areas
+   - Unresolved or unclear dependencies
+   - >7 Acceptance Criteria
+   - ACs contain unconstrained language ("appropriate", "works", "reasonable") with no measurable threshold
+
+4. Build a gap list: label each identified gap and classify as **Blocking** (must resolve before plan) or **Advisory** (can proceed with assumption).
+
+5. Present the complexity verdict and gap list to the user.
+   - **Trivial verdict:** Offer to produce a full plan if needed; otherwise recommend proceeding to `task.start [id]` directly. Stop here unless the user requests a full plan.
+   - **Complex verdict:** Present the gap list and continue to Phase 2.
+
+### Phase 2 — Discovery
+
+6. Identify 1–3 concern areas. For Mode A, derive from the user description. For Mode B, derive from the gap list. Typical concern areas: existing module implementations the task must follow, external service or API behaviour the task depends on, or test infrastructure patterns the task must replicate.
+
+7. Launch one Explore subagent per concern area (in parallel when independent). Each subagent prompt must specify:
+   - The exact concern area to investigate
+   - Thoroughness level: `quick`, `medium`, or `thorough`
+   - What to return: specific files, types, function names, patterns, or API endpoints — not general summaries
+
+8. Update the in-memory plan draft with findings from each subagent. Note any concerns that returned no useful context.
+
+### Phase 3 — Alignment (if blocking gaps remain after Discovery)
+
+9. Use `vscode_askQuestions` iteratively to resolve blocking gaps. Present one logical cluster per invocation, each question paired with a recommended option and rationale. If user answers reveal scope changes, loop back to Phase 2 with updated subagent queries.
+
+10. For advisory gaps the user declines to clarify, document an explicit assumption in the plan draft.
+
+### Phase 4 — Design
+
+11. Draft the execution plan using the following structure:
+
+    ```
+    ## Plan: {Title — 2–10 words}
+
+    {TL;DR — what, why, and recommended approach. 2–4 sentences.}
+
+    **Steps**
+    1. {Step — note "depends on N" or "parallel with step N" when applicable}
+    2. {For 5+ steps, group into named phases, each independently verifiable}
+
+    **Relevant files**
+    - `{full/path/to/file}` — {what to modify or reuse; name specific functions, types, or patterns}
+
+    **Verification**
+    1. {Specific test commands or checks — not generic statements}
+
+    **Decisions**
+    - {Design decisions, assumptions, explicit scope inclusions and exclusions}
+
+    **Further Considerations** (optional, 1–3 items)
+    1. {Clarifying point with trade-off or recommendation}
+    ```
+
+    Rules for the plan body: no code blocks — describe changes using symbol names and file links; every file in Relevant Files must be verified to exist via Discovery or prior codebase knowledge; Decisions must capture all choices made in Phase 3 Q&A.
+
+12. Save the plan to `/memories/session/plan.md` using the `memory` tool (create or overwrite).
+
+13. **Show the full plan to the user.** The memory file is for persistence only — do not substitute it for presenting the plan in chat.
+
+### Phase 5 — Refinement and Next Steps
+
+14. Await user feedback and iterate:
+    - **Changes requested** → revise plan, re-save to `/memories/session/plan.md`, re-show updated plan
+    - **Questions asked** → clarify inline; use `vscode_askQuestions` if follow-up questions are needed
+    - **Alternatives wanted** → loop back to Phase 2 with a new Explore subagent targeting the alternative
+    - **Explicit approval given** → present context-appropriate next steps (step 15)
+
+15. On approval, offer next steps based on mode:
+
+    **Mode A:**
+    Present pre-populated task fields derived from the plan:
+    ```
+    Title: {derived from plan title}
+    Description: {1–3 sentence summary from TL;DR}
+    Acceptance Criteria:
+      - {AC derived from plan}
+    Implementation Steps:
+      - {Step derived from plan}
+    Design Decisions:
+      - {resolved decision from Phase 3}
+    ```
+    Ask the user to confirm. On confirmation, invoke `task.create` with these fields.
+
+    **Mode B:**
+    Offer three options:
+    1. **Start now** — run `task.start [id]` to begin implementation
+    2. **Update task file** — apply resolved Implementation Steps, Design Decisions, and any corrected ACs back to the task file (step 16)
+    3. **Keep for later** — plan is saved in `/memories/session/plan.md`; nothing else to do
+
+16. **Task file update (Mode B, option 2):**
+    - Present a field-by-field summary of proposed changes: current value → new value for each field being updated
+    - Require explicit user confirmation before writing
+    - Write only the fields that have changed: Implementation Steps, Design Decisions, and ACs if the plan reveals they are incorrect or incomplete
+    - Never touch PLANNING.md or any other file
+
+## Output
+
+- `/memories/session/plan.md` — approved execution plan; session-scoped, never committed to git
+- Complexity verdict and gap list (Mode B) — surfaced in chat, not persisted
+- Mode A: pre-populated task fields confirmed before `task.create`
+- Mode B option 2: task file updated with confirmed field changes
+
+## Scope
+
+**In scope:**
+- Reading and assessing any task file by ID (Mode B)
+- Accepting a free-form description to plan a potential new task (Mode A)
+- Launching Explore subagents to gather codebase context
+- Iterative Q&A to resolve design decisions and gaps
+- Writing and refining an execution plan
+- Updating Implementation Steps, Design Decisions, and ACs in the task file after explicit user confirmation (Mode B option 2)
+
+**Out of scope:**
+- Does not implement code or modify source files
+- Does not modify PLANNING.md or any project file other than the specific task file (Mode B option 2 only)
+- Does not run tests, builds, or services
+- Precedes `task.start` — does not replace it
+- Does not validate acceptance criteria — that is `task.complete`'s responsibility
+
+## Examples
+
+### Example 1 — Mode A (pre-create from idea)
+
+**Input:** `task.plan` (no ID), user describes: "I want to add an email notification when a task is marked complete"
+
+- No task ID — Mode A
+- Phase 2: Explore subagents — (a) existing notification or event patterns in the codebase; (b) task completion workflow and trigger points
+- Phase 3: Q&A on delivery mechanism (SMTP vs webhook) and failure handling
+- Phase 4: Plan written and approved; pre-populated fields presented
+- User confirms → `task.create` invoked with Title, Description, ACs, Implementation Steps, and resolved Design Decisions
+
+### Example 2 — Mode B (pre-start, complex task)
+
+**Input:** `task.plan 007`
+
+- Task 007: all Design Decisions are TBD, task is a spike, implementation approach unresolved
+- Verdict: Complex — 3 blocking gaps
+- Phase 2: 2 Explore subagents in parallel — (a) external service API the task depends on; (b) existing module patterns and lifecycle signals
+- Phase 3: Q&A on key design decisions
+- Phase 4: Plan written and approved
+- Next steps offered: user selects option 2 (update task file); proposed changes shown field-by-field; confirmed; task file updated
+
+### Example 3 — Mode B (trivial task)
+
+**Input:** `task.plan 012`
+
+- Task 012: 3 ACs, clear steps, no TBD, all dependencies resolved
+- Verdict: Trivial — all steps defined, no ambiguity
+- Output: "This task looks straightforward. Proceed to `task.start 012`, or request a full plan."
+- User declines full plan → skill ends
+
+## Gotchas
+
+- **Write targets are strictly bounded.** Mode A: `memory` for plan + `task.create` (after confirmation). Mode B: `memory` for plan + specific task file (after confirmation, option 2 only). Never write to PLANNING.md, source files, or any other file.
+- **Complexity verdict is a recommendation, not a gate.** The user can always override and request a full plan for a trivial task, or skip planning for a complex one.
+- **All-TBD Design Decisions require full Discovery + Alignment before drafting the plan.** Skipping this is the root cause of wasted implementation on spike tasks.
+- **Explore subagents must receive an explicit thoroughness level and exact concern area.** Vague prompts ("look at the codebase") return low-value context. Always specify what to find and what to return.
+- **Plan is session-scoped.** `/memories/session/plan.md` is cleared when the session ends. Warn the user if they are resuming a partially planned task in a new session.
+- **Show the plan in chat — do not just mention the file.** The memory file is for persistence and handoff, not a substitute for presenting the plan.
+- **Do not assume Implementation Steps in the task file are current.** Task files are written speculatively at creation time; Discovery may reveal stale steps that reference removed abstractions.
+- **Task file update requires field-by-field confirmation.** Never batch-replace the entire task file. Present exactly what will change and require explicit approval before writing.
+
+## Completion
+
+- [ ] Mode detected (A or B)
+- [ ] Task file read and complexity verdict delivered (Mode B) OR description elicited (Mode A)
+- [ ] All blocking gaps resolved via Q&A or documented as explicit assumptions
+- [ ] Execution plan written to `/memories/session/plan.md`
+- [ ] Full plan shown to user in chat
+- [ ] User has explicitly approved the plan
+- [ ] Appropriate next steps offered and actioned per mode
+
+## Failure Handling
+
+| Situation | Action |
+|-----------|--------|
+| Required input not provided | Request the missing information before proceeding |
+| Gathered input is ambiguous | Flag the ambiguity and ask for clarification |
+| Subagent invocation fails | Report the failure with context; do not silently retry |
+| Output artifact already exists | Confirm with user before overwriting |
+| Task file not found (Mode B) | Report error; ask user to verify task ID; do not proceed |
+| Task file not found (Mode A) | Expected — proceed with user-provided description |
+| Task has no ACs and no Implementation Steps | Flag as incomplete spec; use Q&A to elicit a minimum viable spec before planning; do not produce a plan against an empty task |
+| Explore subagent returns no useful context | Note the gap in the plan as an unresolved unknown; do not retry with the same query |
+| User declines all clarifying questions | Proceed with documented assumptions; mark each assumption explicitly in the Decisions section |
+| `/memories/session/` write fails | Warn user; present full plan in chat only |
+| User approves trivial task without requesting full plan | Confirm `task.start [id]` is the right next step; do not produce an unnecessary plan |
+| Mode A idea too vague to plan | Ask for more detail before launching Discovery; do not proceed with an underspecified description |
+| User confirms task file update | Write only changed fields; confirm completion; do not modify any other section |

--- a/.github/skills/smaqit.test-complete/SKILL.md
+++ b/.github/skills/smaqit.test-complete/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: smaqit.test-complete
+description: Use this skill when finalizing a testing session — verify the playbook's pass/fail criteria against collected execution evidence, generate a standardized test report at `.smaqit/user-testing/YYYY-MM-DD_test-report.md`, and present the result. Use when the user invokes `test.complete`, asks to finalize or wrap up a testing session, or requests a test report. Mirrors `smaqit.task-complete`: the agent executes tests, the user invokes this skill to produce the report.
+metadata:
+  version: "1.0.0"
+---
+
+# Test Complete
+
+Finalize a testing session and produce a standardized test report.
+
+## Steps
+
+### 1. Gather execution evidence
+
+Collect from the testing session context (provided by the testing agent or user):
+
+- Test playbook file path (e.g., `.smaqit/user-testing/tests/NNN_*.md`)
+- Which playbook steps were executed and their pass/fail results
+- Command outputs captured during execution
+- Any failures or unexpected behavior observed
+
+If any of the above is missing, ask the user before proceeding.
+
+### 2. Verify playbook criteria
+
+Read the playbook file. For each checkbox step (`- [ ]`):
+
+- Executed and passed → mark as `- [x]`
+- Skipped (e.g., live-service E2E not applicable) → leave as `- [ ]` and append a `<!-- skipped: <reason> -->` comment
+- Executed and failed → mark as `- [x]` and record the failure detail
+
+Determine the overall verdict:
+
+- **PASS** — all required checkboxes passed, all commands exited 0, live-service responses matched expected behavior
+- **FAIL** — any required checkbox failed or any unexpected failure occurred
+
+### 3. Load report template
+
+Read `references/report-template.md` from this skill's directory. Use it as the skeleton — fill its `{placeholders}` with the evidence from Steps 1–2. Never inline the template in the skill body.
+
+### 4. Write report
+
+Write the completed report to `.smaqit/user-testing/YYYY-MM-DD_test-report.md` using today's date.
+
+Required sections (populated from the template):
+
+- **Date, Repository, Branch, Commit, OS/Arch, Duration** — from session context
+- **Scope** — playbook file reference and commands executed
+- **Checklist** — verified pass/fail per playbook step
+- **Execution Log** — timestamped steps from execution evidence
+- **Results** — overall PASS/FAIL with summary
+- **Pain Points** — blockers, issues, UX friction, performance observations
+- **Recommendations** — concrete improvements based on findings
+
+If a report already exists for today's date, append a `_N` suffix (e.g., `2026-06-09_test-report_2.md`). Inform the user of the disambiguation.
+
+### 5. Present results
+
+Display to the user:
+
+- Report file path
+- Overall verdict (PASS / FAIL)
+- Summary: number of steps passed vs. failed
+- Critical pain points (if any)
+- Suggested next actions
+
+## Output
+
+- `.smaqit/user-testing/YYYY-MM-DD_test-report.md` — completed test report
+
+## Scope
+
+**In scope:**
+
+- Verifying playbook pass/fail criteria against collected execution evidence
+- Generating standardized test reports from `references/report-template.md`
+- Presenting results to the user
+
+**Out of scope:**
+
+- Executing tests — handled by `smaqit.user-testing`
+- Creating playbooks — handled by `smaqit.test-create`
+- Starting test sessions — handled by `smaqit.test-start`
+- Modifying product code
+
+## Examples
+
+**Trigger:** `test.complete` after a testing session for playbook 066.
+
+**Agent actions:**
+1. Gathers evidence: playbook 066 executed, Steps 1–10 all passed, full `dotnet test` output captured
+2. Reads playbook; verifies all 10 step checkboxes
+3. Determines verdict: PASS
+4. Loads `references/report-template.md`
+5. Writes `.smaqit/user-testing/2026-06-09_test-report.md`
+6. Presents: "Report saved. Verdict: PASS. 10/10 steps passing."
+
+**Output:** Report at `.smaqit/user-testing/2026-06-09_test-report.md`. Verdict: PASS.
+
+## Gotchas
+
+- **Report date uses the current date, not the playbook creation date.** The playbook may have been authored on a different day.
+- **Evidence must come from the execution session, not inferred.** If a command output was not captured, mark that step as "unverified" — do not guess.
+- **Pain points are observations, not root cause analysis.** Report what happened: "`dotnet test` exited with code 1" not "The test failed because the service wasn't running."
+- **Report filename uniqueness:** if today's report already exists, disambiguate with `_2`, `_3`, etc.
+- **The report template lives in `references/report-template.md`** — read it with `read_file` before writing; never inline it.
+
+## Completion
+
+- [ ] Execution evidence gathered (playbook path, step results, command outputs, failures)
+- [ ] Playbook criteria verified — all checkboxes assessed
+- [ ] Report template loaded from `references/report-template.md`
+- [ ] Complete report written to `.smaqit/user-testing/YYYY-MM-DD_test-report.md`
+- [ ] All required report sections present
+- [ ] Overall verdict determined (PASS or FAIL)
+- [ ] Results presented to user
+
+## Failure Handling
+
+| Situation | Action |
+|-----------|--------|
+| Required input not provided | Request the missing information before proceeding |
+| Gathered input is ambiguous | Flag the ambiguity and ask for clarification |
+| Execution evidence missing or incomplete | Ask user to provide the missing details; do not proceed without them |
+| Playbook file not found at the provided path | Ask user to confirm the playbook path; if genuinely missing, generate a minimal report from available evidence |
+| Report template (`references/report-template.md`) not found | Use the hardcoded minimal structure from Step 4; report the missing template to the user |
+| Report already exists for today | Append `_N` suffix; inform user of the disambiguation |
+| Evidence contradicts playbook — step claimed passed but evidence shows failure | Flag the discrepancy; mark overall verdict as FAIL; record in pain points |
+| Report write fails (disk full, permissions) | Log the error, attempt a simplified report at an alternate path, notify user |
+| Output artifact already exists | Confirm with user before overwriting (only applies to non-date-disambiguated paths) |

--- a/.github/skills/smaqit.test-complete/references/report-template.md
+++ b/.github/skills/smaqit.test-complete/references/report-template.md
@@ -1,0 +1,52 @@
+# Report Template
+
+> Canonical Markdown structure for all test reports. Load this when completing a testing session via `smaqit.test-complete`. Fill `{placeholders}` with execution evidence.
+
+---
+
+```markdown
+# User Testing Report
+
+**Date:** YYYY-MM-DD
+**Repository:** <owner/repo or folder>
+**Branch:** <branch>
+**Commit:** <sha>
+**OS/Arch:** <os>/<arch>
+**Duration:** <start-end or minutes>
+
+## Scope
+- Test file: <TEST_NUMBER or none>
+- Commands executed:
+   - <command 1>
+   - <command 2>
+
+## Checklist
+- [ ] Test command discovered and confirmed
+- [ ] Dependencies installed (if required)
+- [ ] Test suite executed
+- [ ] Results captured (pass/fail + key errors)
+- [ ] Evidence collected (per test file, if provided)
+
+## Execution Log (Timestamped)
+- HH:MM - <step description>
+- HH:MM - <step description>
+
+## Results
+- Overall: PASS/FAIL
+- Summary:
+   - <high-level outcome, pass/fail counts, key metrics>
+
+## Pain Points
+- Blockers:
+   - <blocker — critical issue preventing progress>
+- Issues:
+   - <issue — problem that affects user experience>
+- UX Friction:
+   - <friction — workflow awkwardness or confusion>
+- Performance:
+   - <performance concern — timing or resource issue>
+
+## Recommendations
+- <concrete, actionable improvement suggestion>
+- <another suggestion>
+```

--- a/.github/skills/smaqit.test-create/SKILL.md
+++ b/.github/skills/smaqit.test-create/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: smaqit.test-create
+description: Creates a test playbook for a task — `task.test-create [id]`, `test.create [id]`, or any request to generate an E2E test runbook from a task file. Produces a complete, executable playbook under `.smaqit/user-testing/tests/` with build-gate, deploy-gate, and live-service E2E validation where the task touches live services.
+metadata:
+  version: "1.0.0"
+---
+
+# Test Playbook Creator
+
+## Steps
+
+### 1. Gather task context
+
+Collect from the user or from the task file (`.smaqit/tasks/NNN_*.md`):
+
+- Task ID (NNN)
+- Task title
+- What the task changes (paths, services, abilities, config)
+- Whether the task touches any live service: orchestrator, Discord, WebSocket, vLLM, Hindsight, RAG, TTS, STT
+
+If the task file is not found, ask the user to verify the task ID. Do not proceed without confirmation.
+
+### 2. Determine required sections
+
+Every playbook MUST include:
+
+- Objectives (2–4 sentences)
+- Prerequisites (services, tools, access)
+- Step 1: Build & Unit Test Gate — `dotnet build Iodis.sln --nologo --verbosity quiet` exits 0, then `dotnet test Iodis.sln --nologo --verbosity quiet` exits 0
+- Step 2: Deploy & Start Orchestrator — `bash scripts/start/orchestrator-start.sh` then `bash scripts/health/health.sh`
+- Pass/Fail Criteria
+- Evidence to Capture
+
+**Conditional — Step 3: Live Service E2E.** Include iff the task touches ANY live service (orchestrator, Discord, WebSocket, vLLM, Hindsight, RAG, TTS, STT). Must contain:
+
+- Turn-by-turn instructions with exact input per turn
+- Expected output/behavior per turn
+- How to verify each turn (response content, `journalctl -u iodis-orchestrator --since "2 min ago" --no-pager | grep "…"`, Metadata key via `jq`)
+- A `wscat -c ws://localhost:5000/ws` WebSocket fallback with the note: "If Discord token is unavailable, use WebSocket fallback."
+
+**Conditional — Step N: Additional Validation.** Include only if the task requires config checks (`jq` against `appconfig.json`), log checks, or other domain-specific validation beyond the standard gates.
+
+### 3. Load the playbook template
+
+Read `references/playbook-template.md` from this skill's directory. Use it as the canonical skeleton — fill in every `{placeholder}` with task-specific details from Steps 1–2.
+
+### 4. Write the playbook
+
+Write to `.smaqit/user-testing/tests/{NNN}_{slug}.md`. Derive the slug from the task title: lowercase, hyphens, drop leading article words and the task number.
+
+Rules:
+
+- `scripts/start/orchestrator-start.sh` is idempotent — it rebuilds, redeploys, and restarts the systemd unit. Never include separate `dotnet publish`, `serve_daisy.sh`, or manual systemd restart steps.
+- `scripts/health/health.sh` is the single source of truth for service health. Never check individual ports manually.
+- Every live-service E2E turn must specify: exact input, expected output/behavior, and how to verify.
+- If the playbook file already exists, ask whether to overwrite or use a different name.
+
+### 5. Report
+
+Report to the user:
+
+- Path of the created playbook
+- Sections included (Build Gate, Deploy, Live Service E2E, Additional Validation)
+- If Live Service E2E is included, list the verification methods used (Discord, WebSocket, journalctl)
+
+## Output
+
+- `.smaqit/user-testing/tests/{NNN}_{slug}.md` — complete, executable test playbook
+
+## Scope
+
+**In scope:** Creating new test playbooks for existing tasks; determining required sections from task context; including live-service E2E where applicable.
+
+**Out of scope:** Executing playbooks (`smaqit.test-start`); modifying existing playbooks (edit directly); creating task files or modifying `PLANNING.md`.
+
+## Examples
+
+**Request:** `task.test-create 058`
+
+**Agent actions:**
+1. Reads `.smaqit/tasks/058_coder_session_service.md`
+2. Determines: task touches orchestrator and Discord
+3. Loads `references/playbook-template.md`
+4. Writes `.smaqit/user-testing/tests/058_coder-session-e2e.md` with Build Gate, Deploy, Live Service E2E (Discord turns + journalctl verification), and Evidence checklist
+
+**Output:** Playbook created at `.smaqit/user-testing/tests/058_coder-session-e2e.md`. Sections: Build Gate, Deploy, Live Service E2E (Discord + journalctl).
+
+## Gotchas
+
+- `scripts/start/orchestrator-start.sh` is idempotent — it rebuilds the solution, copies to runtime, and restarts the systemd unit. Never include separate build, publish, or restart steps.
+- `scripts/health/health.sh` is the single source of truth for service health. Always use it after deploy; never check individual ports manually.
+- Discord tokens may be absent from the test environment. Always provide a `wscat`-based WebSocket fallback with the note: "If Discord token is unavailable, use WebSocket fallback."
+- Journalctl `--since` values: use `"2 min ago"` for sequential turns. Adjust if the playbook has longer delays between steps.
+- Playbook filename derives from the task title slug, not the raw task filename. Example: "021 — Assistant Multi-Turn Session Context" → `021_assistant-session-context.md`.
+
+## Completion
+
+- [ ] Task context gathered (ID, title, what it touches)
+- [ ] Required sections determined
+- [ ] Playbook template loaded from `references/playbook-template.md`
+- [ ] Complete playbook written to `.smaqit/user-testing/tests/{NNN}_{slug}.md`
+- [ ] Build Gate step present
+- [ ] Deploy step present
+- [ ] Live Service E2E step present iff task touches live services
+- [ ] No separate `dotnet publish`, `serve_daisy.sh`, or manual systemd restart anti-patterns
+- [ ] User informed of created file path
+
+## Failure Handling
+
+| Situation | Action |
+|-----------|--------|
+| Required input not provided | Request the missing information before proceeding |
+| Gathered input is ambiguous | Flag the ambiguity and ask for clarification |
+| Task ID not found in `.smaqit/tasks/` | Ask user to verify task ID; do not proceed without confirmation |
+| Playbook already exists | Ask user: overwrite or create with different name |
+| Template file not found at `references/playbook-template.md` | Use the hardcoded minimal structure from this skill's Steps section; report the missing template |
+| Task context unclear (vague description) | Infer from task file ACs and implementation steps; flag assumptions to user |

--- a/.github/skills/smaqit.test-create/references/playbook-template.md
+++ b/.github/skills/smaqit.test-create/references/playbook-template.md
@@ -1,0 +1,68 @@
+# Playbook Template
+
+> Canonical Markdown structure for all test playbooks. Load this when creating a new playbook via `smaqit.test-create`. Fill in `{placeholders}` with task-specific details.
+
+---
+
+```markdown
+# {Title} — E2E Test Playbook
+
+**Test ID:** {NNN}
+**Title:** {Task title}
+**Date:** YYYY-MM-DD
+**Tester:** User Testing Agent
+**Task:** {NNN}
+
+## Objectives
+{What this playbook validates — 2-4 sentences}
+
+## Prerequisites
+- {Required services, tools, access}
+- {Example: Discord bot token in appconfig.local.json (or use WebSocket fallback)}
+- {Example: wscat or Electron UI for WebSocket}
+
+## Test Steps
+
+### Step 1 — Build & Unit Test Gate
+- [ ] `dotnet build Iodis.sln --nologo --verbosity quiet` exits 0
+- [ ] `dotnet test Iodis.sln --nologo --verbosity quiet` exits 0 (zero failures)
+
+### Step 2 — Deploy & Start Orchestrator
+- [ ] `bash scripts/start/orchestrator-start.sh` — rebuilds, redeploys, restarts systemd unit
+- [ ] `bash scripts/health/health.sh` — all services report healthy
+
+### Step 3 — Live Service E2E {REMOVE THIS STEP IF TASK DOES NOT TOUCH LIVE SERVICES}
+
+{For Discord-based E2E:}
+
+- [ ] Turn 1: send "{exact Discord message}" in test channel → verify response {expected behavior}
+- [ ] Turn 2: send "{exact Discord message}" → verify response {expected behavior}
+- [ ] Verify in journald: `journalctl -u iodis-orchestrator --since "2 min ago" --no-pager | grep "{key log line}"`
+
+{For WebSocket-based E2E (fallback or primary):}
+
+- [ ] Connect: `wscat -c ws://localhost:5000/ws`
+- [ ] Turn 1: send `{"input":"{exact input}"}` → verify response contains "{expected text}"
+- [ ] Turn 2: send `{"input":"{exact input}"}` → verify response contains "{expected text}"
+- [ ] Verify in journald: `journalctl -u iodis-orchestrator --since "2 min ago" --no-pager | grep "{key log line}"`
+
+{If Discord token unavailable, add note:}
+> Note: If Discord token is unavailable, use the WebSocket fallback steps below. Connect via `wscat` instead of Discord client.
+
+### Step N — Additional Validation
+
+- [ ] {Config check, log check, or other validation}
+- [ ] {Example: verify appconfig.json entry with `jq`}
+
+## Pass/Fail Criteria
+
+**PASS** — All checkboxes are checked. All commands exit 0. Live-service responses match expected behavior.
+**FAIL** — Any checkbox unchecked. Any unexpected failure or incorrect response.
+
+## Evidence to Capture
+
+- Output of `dotnet test Iodis.sln` (pass/fail summary line)
+- Output of `bash scripts/health/health.sh` (all services line)
+- {Turn-by-turn inputs and responses for live service E2E}
+- Relevant journald log excerpts: `journalctl -u iodis-orchestrator --since "5 min ago" --no-pager | grep -E "{pattern}"`
+```

--- a/.github/skills/smaqit.test-start/SKILL.md
+++ b/.github/skills/smaqit.test-start/SKILL.md
@@ -2,7 +2,7 @@
 name: smaqit.test-start
 description: Start testing session with focused context. Use when beginning test workflows with the user-testing agent.
 metadata:
-  version: "0.3.0"
+  version: "0.3.1"
 agent: smaqit.user-testing
 ---
 
@@ -34,7 +34,7 @@ Read the project files that define how tests are run (whichever exist):
 Read the complete test file:
 - `.smaqit/user-testing/tests/{TEST_NUMBER}_*.md`
 
-If the test file does not exist, ask whether to create it under `.smaqit/user-testing/tests/` before proceeding.
+If the test file does not exist, ask whether to create it by invoking `smaqit.test-create` before proceeding.
 
 This file contains:
 - Test objectives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to smaqit-extensions will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2026-06-21
+
+### Added
+- **`smaqit.test-create` skill v1.0.0** — creates structured E2E test playbooks from task files with build-gate, deploy-gate, and live-service E2E validation (#108)
+- **`smaqit.test-complete` skill v1.0.0** — finalizes testing sessions by verifying pass/fail criteria and generating standardized test reports (#108)
+
+### Changed
+- **`smaqit.test-start` skill** — refined to delegate report generation to `smaqit.test-complete`; updated directives and workflow phases (#108)
+- **`smaqit.user-testing` agent v0.5.0** — updated to hand off report generation to `smaqit.test-complete`; refined directives and tool specifications (#108)
+- **Makefile** — added `smaqit.test-create`, `smaqit.test-complete`, `smaqit.task-plan`, `smaqit.task-refresh` to sync list; all 27 skills now synced to `.github/`
+- Release version metadata updated to 1.3.0 in installer sources (`installer/main.go`, `installer/Makefile`)
 
 ## [1.2.0] - 2026-06-03
 
@@ -469,7 +479,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Go-based installer for cross-platform installation
 - Bash install script with version mode support
 
-[Unreleased]: https://github.com/ruifrvaz/smaqit-extensions/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/ruifrvaz/smaqit-extensions/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/ruifrvaz/smaqit-extensions/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/ruifrvaz/smaqit-extensions/compare/v1.1.5...v1.2.0
 [1.1.5]: https://github.com/ruifrvaz/smaqit-extensions/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/ruifrvaz/smaqit-extensions/compare/v1.1.3...v1.1.4

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ sync:
 	@echo "Syncing source files to .github/..."
 	@mkdir -p .github/agents .github/skills
 	@cp -f agents/*.md .github/agents/
-	@for skill in smaqit.session-start smaqit.session-finish smaqit.session-assess smaqit.session-title smaqit.session-recap smaqit.task-create smaqit.task-list smaqit.task-complete smaqit.task-start smaqit.test-start smaqit.project-init smaqit.project-glossary smaqit.release-analysis smaqit.release-approval smaqit.release-prepare-files smaqit.release-git-local smaqit.release-git-pr smaqit.utils.read-pdf smaqit.utils.triage-issues smaqit.project-research smaqit.project-recap smaqit.project-compendium smaqit.parity-assess; do \
+	@for skill in smaqit.session-start smaqit.session-finish smaqit.session-assess smaqit.session-title smaqit.session-recap smaqit.task-create smaqit.task-list smaqit.task-complete smaqit.task-plan smaqit.task-refresh smaqit.task-start smaqit.test-create smaqit.test-complete smaqit.test-start smaqit.project-init smaqit.project-glossary smaqit.release-analysis smaqit.release-approval smaqit.release-prepare-files smaqit.release-git-local smaqit.release-git-pr smaqit.utils.read-pdf smaqit.utils.triage-issues smaqit.project-research smaqit.project-recap smaqit.project-compendium smaqit.parity-assess; do \
 		mkdir -p .github/skills/$$skill; \
 		cp -f skills/$$skill/SKILL.md .github/skills/$$skill/; \
 		if [ -d skills/$$skill/references ]; then \

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Enhance your agentic development with streamlined session management, task track
 
 #### Testing
 - **smaqit.test-start** - Initialize testing workflows
+- **smaqit.test-create** - Create structured E2E test playbooks from task files with build-gate, deploy-gate, and live-service E2E validation
+- **smaqit.test-complete** - Finalize testing sessions by verifying pass/fail criteria and generating standardized test reports
 
 #### Release Management
 - **smaqit.release-analysis** - Collect changes, assess severity, and suggest next version
@@ -46,7 +48,7 @@ Enhance your agentic development with streamlined session management, task track
 ### Utility Agents
 - **@smaqit.release.local** - Automated release management (local development)
 - **@smaqit.release.pr** - Automated release management (PR-based, CI/CD)
-- **@smaqit.user-testing** - End-to-end testing workflows
+- **@smaqit.user-testing** - End-to-end testing workflorkflow
 
 ## Installation
 
@@ -66,7 +68,7 @@ curl -fsSL https://raw.githubusercontent.com/ruifrvaz/smaqit-extensions/main/ins
 
 The installer copies files to your project's `.github/` directory:
 - `agents/` - 3 utility agents (release local, release PR, user-testing)
-- `skills/` - 23 workflow skills (complete implementations)
+- `skills/` - 25 workflow skills (complete implementations)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Enhance your agentic development with streamlined session management, task track
 ### Utility Agents
 - **@smaqit.release.local** - Automated release management (local development)
 - **@smaqit.release.pr** - Automated release management (PR-based, CI/CD)
-- **@smaqit.user-testing** - End-to-end testing workflorkflow
+- **@smaqit.user-testing** - End-to-end testing workflow
 
 ## Installation
 
@@ -68,7 +68,7 @@ curl -fsSL https://raw.githubusercontent.com/ruifrvaz/smaqit-extensions/main/ins
 
 The installer copies files to your project's `.github/` directory:
 - `agents/` - 3 utility agents (release local, release PR, user-testing)
-- `skills/` - 25 workflow skills (complete implementations)
+- `skills/` - 27 workflow skills (complete implementations)
 
 ## Usage
 

--- a/agents/smaqit.user-testing.agent.md
+++ b/agents/smaqit.user-testing.agent.md
@@ -2,8 +2,8 @@
 name: smaqit.user-testing
 description: End-to-end user testing agent that validates a project's test workflow and produces a standardized report
 metadata:
-  version: "0.4.0"
-tools: ['edit', 'search', 'runCommands', 'usages', 'problems', 'changes', 'testFailure', 'todos', 'runTests']
+  version: "0.5.0"
+tools: ['edit', 'search', 'execute/getTerminalOutput', 'execute/runInTerminal', 'read/terminalLastCommand', 'read/terminalSelection', 'search/usages', 'read/problems', 'execute/testFailure', 'todo', 'execute/runTests']
 ---
 
 # Testing Agent
@@ -26,15 +26,7 @@ You are the e2e testing agent. Your goal is to validate the end-to-end testing e
 
 ## Output
 
-**Location:** `.smaqit/user-testing/YYYY-MM-DD_test-report.md`
-
-**Format:** Use this strict template (do not depend on any external template file):
-- Test information (date, version, OS, duration)
-- Standardized checklist (pass/fail per validation point)
-- Execution log (timestamped steps)
-- Painpoints identified (blockers, issues, UX friction, performance)
-- Recommendations for improvements
-- Overall result (PASS/FAIL)
+The agent executes test steps and captures an execution log. After execution, the agent instructs the user to invoke `smaqit.test-complete` to generate the standardized report at `.smaqit/user-testing/YYYY-MM-DD_test-report.md`.
 
 ## Test Workflow
 
@@ -60,149 +52,57 @@ You are the e2e testing agent. Your goal is to validate the end-to-end testing e
 3. **Load a specific test file (optional)**
    - If user provides a test number, read the complete test file: `.smaqit/user-testing/tests/{TEST_NUMBER}_*.md`.
    - Extract: objectives, evidence requirements, pass/fail criteria, and any required setup.
-   - If the test file doesn't exist, ask whether to create it under `.smaqit/user-testing/tests/` or proceed without it.
+   - If the test file doesn't exist, ask whether to create it by invoking `smaqit.test-create` or proceed without it.
 
 ### Phase 3: Execute Tests
 
 4. **Run the test workflow**
    - Execute the agreed test command(s).
    - Capture command output summaries (not full logs unless asked).
-   - If tests fail, stop immediately — do not attempt any fix or workaround.
-   - Diagnose the root cause of every failure: trace the error, identify the likely origin, and formulate a concrete proposed fix.
-   - Record each diagnosed bug and its proposed fix in the **Follow-up Fixes** section of the report for later implementation.
+   - If tests fail, attempt the most obvious next step (e.g. install deps) once; otherwise stop changing things and report the failure clearly.
+   - Do not modify product code unless the user explicitly asks you to fix issues.
 
-### Phase 4: Report Generation and Cleanup
+### Phase 4: Handoff to Completion
 
-5. **Generate comprehensive report**
-    - Ensure `.smaqit/user-testing/` exists.
-    - Save report to `.smaqit/user-testing/YYYY-MM-DD_test-report.md`.
-    - Template:
-
-```markdown
-# User Testing Report
-
-**Date:** YYYY-MM-DD
-**Repository:** <owner/repo or folder>
-**Branch:** <branch>
-**Commit:** <sha>
-**OS/Arch:** <os>/<arch>
-**Duration:** <start-end or minutes>
-
-## Scope
-- Test file: <TEST_NUMBER or none>
-- Commands executed:
-   - <command 1>
-   - <command 2>
-
-## Checklist
-- [ ] Test command discovered and confirmed
-- [ ] Dependencies installed (if required)
-- [ ] Test suite executed
-- [ ] Results captured (pass/fail + key errors)
-- [ ] Evidence collected (per test file, if provided)
-
-## Execution Log (Timestamped)
-- HH:MM - <step>
-
-## Results
-- Overall: PASS/FAIL
-- Summary:
-   - <high level outcome>
-
-## Pain Points
-- Blockers:
-   - <blocker>
-- Issues:
-   - <issue>
-- UX Friction:
-   - <friction>
-
-## Recommendations
-- <recommendation>
-
-## Follow-up Fixes
-- <bug description> → <proposed fix>
-```
-
-6. **Present results to user**
-    - Display report location
-    - Show overall result (PASS/FAIL)
-    - Highlight critical painpoints if any
-    - Suggest next actions based on outcome
+5. **After execution finishes**, instruct the user to invoke `smaqit.test-complete` to generate the report. The agent MUST NOT write the report itself — report generation is the responsibility of `smaqit.test-complete`.
 
 ## Directives
 
 **Testing Agent MUST:**
-- Follow the standardized report template exactly
+- Execute the test workflow as defined in the playbook
+- Capture command output summaries (not full logs unless asked)
 - Continue execution even when individual steps fail (unless further progress is impossible)
-- Record all failures in the painpoints section
-- Generate timestamped execution log
-- Identify painpoints objectively (what happened, not why)
-- When a bug is detected, diagnose its root cause, determine the likely origin, and record a concrete proposed fix in the **Follow-up Fixes** section of the report
+- Record all observations for handoff to `smaqit.test-complete`
+- Do NOT modify product code unless the user explicitly asks
 
 **Testing Agent MUST NOT:**
-- Skip report generation if tests fail
-- Implement bugfixes or code changes under any circumstances, even when the fix appears obvious or the user asks
-- Modify the project's product code in any way
+- Write the test report (this is `smaqit.test-complete`'s responsibility)
+- Make assumptions about why failures occurred (report observations only)
+- Skip steps — execute the playbook in order
 
 **Testing Agent SHOULD:**
 - Use absolute paths for all file operations
 - Capture command outputs in execution log
-- Record exact error messages in painpoints section
+- Record exact error messages
 - Note unexpected behavior even if tests pass
-- Suggest concrete improvements in recommendations section
-
-**Interactive Workflow Note:**
-- Agent cannot invoke prompts programmatically (prompts are chat commands)
-- Agent coordinates testing by instructing user to execute prompts
-- Agent automates setup, validation, cleanup, and reporting
-- User executes prompts step-by-step and confirms completion after each
 
 ## Completion Criteria
 
-Testing is complete when:
+Test execution is complete when:
 
 - [ ] Environment details recorded
 - [ ] Test command(s) discovered and confirmed
 - [ ] Test suite executed (or failure documented)
-- [ ] Comprehensive report generated following template
-- [ ] Report saved to `.smaqit/user-testing/YYYY-MM-DD_test-report.md`
-- [ ] Overall result determined (PASS/FAIL)
+- [ ] Execution log captured for handoff to `smaqit.test-complete`
 
 ## Failure Handling
 
 | Failure | Response |
 |---------|----------|
 | Test command unclear | Ask user to confirm intended command(s); proceed once confirmed |
-| Dependencies missing | Record in painpoints; optionally run the standard install step once; re-run tests |
+| Dependencies missing | Record in observations; optionally run the standard install step once; re-run tests |
 | Tests fail | Record failure and key errors; do not attempt deeper fixes unless user asks |
-| Report write fails | Log error, attempt simplified report, stop |
-
-## Validation Philosophy
-
-**Minimal Validation:**
-- File existence checks only
-- No content validation (no checking for section headers, requirement IDs, etc.)
-- Rationale: Content validation is the job of `smaqit validate` command
-
-**User Experience Focus:**
-- Does the workflow execute smoothly?
-- Are prompts clear and helpful?
-- Are error messages actionable?
-- Is the process intuitive for new users?
-
-**Painpoint Identification:**
-- Blockers: Critical issues preventing progress
-- Issues: Problems that affect user experience
-- UX Friction: Workflow awkwardness or confusion
-- Performance: Timing or resource concerns
 
 ## Repeatable Test Runs
 
-If you want repeatable testing runs, define a test file in `.smaqit/user-testing/tests/NNN_*.md` that captures:
-- Setup prerequisites
-- Exact commands to run
-- Evidence to collect
-- Pass/fail criteria
-
-**Tip:** Load test files at the start of a session with the `smaqit.test-start` skill.
+If you want repeatable testing runs, define a test file in `.smaqit/user-testing/tests/NNN_*.md`. Use `smaqit.test-create` to generate one from a task file.

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build clean test prepare
 
-VERSION ?= 1.2.0
+VERSION ?= 1.3.0
 
 prepare:
 	@echo "Preparing build environment..."

--- a/installer/main.go
+++ b/installer/main.go
@@ -25,7 +25,7 @@ var skillFiles embed.FS
 var templateFiles embed.FS
 
 // Version is set via ldflags during build: -X main.Version=$(VERSION)
-var Version = "1.2.0"
+var Version = "1.3.0"
 
 const planningTemplate = `# Task Planning
 

--- a/installer/main.go
+++ b/installer/main.go
@@ -100,7 +100,7 @@ func printHelp() {
 	fmt.Println()
 	fmt.Println("What gets installed:")
 	fmt.Println("  .github/agents/     - 3 utility agents")
-	fmt.Println("  .github/skills/     - 22 workflow skills")
+	fmt.Println("  .github/skills/     - 25 workflow skills")
 	fmt.Println("  .smaqit/templates/  - 3 canonical templates")
 }
 

--- a/skills/smaqit.test-complete/SKILL.md
+++ b/skills/smaqit.test-complete/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: smaqit.test-complete
+description: Use this skill when finalizing a testing session — verify the playbook's pass/fail criteria against collected execution evidence, generate a standardized test report at `.smaqit/user-testing/YYYY-MM-DD_test-report.md`, and present the result. Use when the user invokes `test.complete`, asks to finalize or wrap up a testing session, or requests a test report. Mirrors `smaqit.task-complete`: the agent executes tests, the user invokes this skill to produce the report.
+metadata:
+  version: "1.0.0"
+---
+
+# Test Complete
+
+Finalize a testing session and produce a standardized test report.
+
+## Steps
+
+### 1. Gather execution evidence
+
+Collect from the testing session context (provided by the testing agent or user):
+
+- Test playbook file path (e.g., `.smaqit/user-testing/tests/NNN_*.md`)
+- Which playbook steps were executed and their pass/fail results
+- Command outputs captured during execution
+- Any failures or unexpected behavior observed
+
+If any of the above is missing, ask the user before proceeding.
+
+### 2. Verify playbook criteria
+
+Read the playbook file. For each checkbox step (`- [ ]`):
+
+- Executed and passed → mark as `- [x]`
+- Skipped (e.g., live-service E2E not applicable) → leave as `- [ ]` and append a `<!-- skipped: <reason> -->` comment
+- Executed and failed → mark as `- [x]` and record the failure detail
+
+Determine the overall verdict:
+
+- **PASS** — all required checkboxes passed, all commands exited 0, live-service responses matched expected behavior
+- **FAIL** — any required checkbox failed or any unexpected failure occurred
+
+### 3. Load report template
+
+Read `references/report-template.md` from this skill's directory. Use it as the skeleton — fill its `{placeholders}` with the evidence from Steps 1–2. Never inline the template in the skill body.
+
+### 4. Write report
+
+Write the completed report to `.smaqit/user-testing/YYYY-MM-DD_test-report.md` using today's date.
+
+Required sections (populated from the template):
+
+- **Date, Repository, Branch, Commit, OS/Arch, Duration** — from session context
+- **Scope** — playbook file reference and commands executed
+- **Checklist** — verified pass/fail per playbook step
+- **Execution Log** — timestamped steps from execution evidence
+- **Results** — overall PASS/FAIL with summary
+- **Pain Points** — blockers, issues, UX friction, performance observations
+- **Recommendations** — concrete improvements based on findings
+
+If a report already exists for today's date, append a `_N` suffix (e.g., `2026-06-09_test-report_2.md`). Inform the user of the disambiguation.
+
+### 5. Present results
+
+Display to the user:
+
+- Report file path
+- Overall verdict (PASS / FAIL)
+- Summary: number of steps passed vs. failed
+- Critical pain points (if any)
+- Suggested next actions
+
+## Output
+
+- `.smaqit/user-testing/YYYY-MM-DD_test-report.md` — completed test report
+
+## Scope
+
+**In scope:**
+
+- Verifying playbook pass/fail criteria against collected execution evidence
+- Generating standardized test reports from `references/report-template.md`
+- Presenting results to the user
+
+**Out of scope:**
+
+- Executing tests — handled by `smaqit.user-testing`
+- Creating playbooks — handled by `smaqit.test-create`
+- Starting test sessions — handled by `smaqit.test-start`
+- Modifying product code
+
+## Examples
+
+**Trigger:** `test.complete` after a testing session for playbook 066.
+
+**Agent actions:**
+1. Gathers evidence: playbook 066 executed, Steps 1–10 all passed, full `dotnet test` output captured
+2. Reads playbook; verifies all 10 step checkboxes
+3. Determines verdict: PASS
+4. Loads `references/report-template.md`
+5. Writes `.smaqit/user-testing/2026-06-09_test-report.md`
+6. Presents: "Report saved. Verdict: PASS. 10/10 steps passing."
+
+**Output:** Report at `.smaqit/user-testing/2026-06-09_test-report.md`. Verdict: PASS.
+
+## Gotchas
+
+- **Report date uses the current date, not the playbook creation date.** The playbook may have been authored on a different day.
+- **Evidence must come from the execution session, not inferred.** If a command output was not captured, mark that step as "unverified" — do not guess.
+- **Pain points are observations, not root cause analysis.** Report what happened: "`dotnet test` exited with code 1" not "The test failed because the service wasn't running."
+- **Report filename uniqueness:** if today's report already exists, disambiguate with `_2`, `_3`, etc.
+- **The report template lives in `references/report-template.md`** — read it with `read_file` before writing; never inline it.
+
+## Completion
+
+- [ ] Execution evidence gathered (playbook path, step results, command outputs, failures)
+- [ ] Playbook criteria verified — all checkboxes assessed
+- [ ] Report template loaded from `references/report-template.md`
+- [ ] Complete report written to `.smaqit/user-testing/YYYY-MM-DD_test-report.md`
+- [ ] All required report sections present
+- [ ] Overall verdict determined (PASS or FAIL)
+- [ ] Results presented to user
+
+## Failure Handling
+
+| Situation | Action |
+|-----------|--------|
+| Required input not provided | Request the missing information before proceeding |
+| Gathered input is ambiguous | Flag the ambiguity and ask for clarification |
+| Execution evidence missing or incomplete | Ask user to provide the missing details; do not proceed without them |
+| Playbook file not found at the provided path | Ask user to confirm the playbook path; if genuinely missing, generate a minimal report from available evidence |
+| Report template (`references/report-template.md`) not found | Use the hardcoded minimal structure from Step 4; report the missing template to the user |
+| Report already exists for today | Append `_N` suffix; inform user of the disambiguation |
+| Evidence contradicts playbook — step claimed passed but evidence shows failure | Flag the discrepancy; mark overall verdict as FAIL; record in pain points |
+| Report write fails (disk full, permissions) | Log the error, attempt a simplified report at an alternate path, notify user |
+| Output artifact already exists | Confirm with user before overwriting (only applies to non-date-disambiguated paths) |

--- a/skills/smaqit.test-complete/references/report-template.md
+++ b/skills/smaqit.test-complete/references/report-template.md
@@ -1,0 +1,52 @@
+# Report Template
+
+> Canonical Markdown structure for all test reports. Load this when completing a testing session via `smaqit.test-complete`. Fill `{placeholders}` with execution evidence.
+
+---
+
+```markdown
+# User Testing Report
+
+**Date:** YYYY-MM-DD
+**Repository:** <owner/repo or folder>
+**Branch:** <branch>
+**Commit:** <sha>
+**OS/Arch:** <os>/<arch>
+**Duration:** <start-end or minutes>
+
+## Scope
+- Test file: <TEST_NUMBER or none>
+- Commands executed:
+   - <command 1>
+   - <command 2>
+
+## Checklist
+- [ ] Test command discovered and confirmed
+- [ ] Dependencies installed (if required)
+- [ ] Test suite executed
+- [ ] Results captured (pass/fail + key errors)
+- [ ] Evidence collected (per test file, if provided)
+
+## Execution Log (Timestamped)
+- HH:MM - <step description>
+- HH:MM - <step description>
+
+## Results
+- Overall: PASS/FAIL
+- Summary:
+   - <high-level outcome, pass/fail counts, key metrics>
+
+## Pain Points
+- Blockers:
+   - <blocker — critical issue preventing progress>
+- Issues:
+   - <issue — problem that affects user experience>
+- UX Friction:
+   - <friction — workflow awkwardness or confusion>
+- Performance:
+   - <performance concern — timing or resource issue>
+
+## Recommendations
+- <concrete, actionable improvement suggestion>
+- <another suggestion>
+```

--- a/skills/smaqit.test-create/SKILL.md
+++ b/skills/smaqit.test-create/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: smaqit.test-create
+description: Creates a test playbook for a task — `task.test-create [id]`, `test.create [id]`, or any request to generate an E2E test runbook from a task file. Produces a complete, executable playbook under `.smaqit/user-testing/tests/` with build-gate, deploy-gate, and live-service E2E validation where the task touches live services.
+metadata:
+  version: "1.0.0"
+---
+
+# Test Playbook Creator
+
+## Steps
+
+### 1. Gather task context
+
+Collect from the user or from the task file (`.smaqit/tasks/NNN_*.md`):
+
+- Task ID (NNN)
+- Task title
+- What the task changes (paths, services, abilities, config)
+- Whether the task touches any live service: orchestrator, Discord, WebSocket, vLLM, Hindsight, RAG, TTS, STT
+
+If the task file is not found, ask the user to verify the task ID. Do not proceed without confirmation.
+
+### 2. Determine required sections
+
+Every playbook MUST include:
+
+- Objectives (2–4 sentences)
+- Prerequisites (services, tools, access)
+- Step 1: Build & Unit Test Gate — `dotnet build Iodis.sln --nologo --verbosity quiet` exits 0, then `dotnet test Iodis.sln --nologo --verbosity quiet` exits 0
+- Step 2: Deploy & Start Orchestrator — `bash scripts/start/orchestrator-start.sh` then `bash scripts/health/health.sh`
+- Pass/Fail Criteria
+- Evidence to Capture
+
+**Conditional — Step 3: Live Service E2E.** Include iff the task touches ANY live service (orchestrator, Discord, WebSocket, vLLM, Hindsight, RAG, TTS, STT). Must contain:
+
+- Turn-by-turn instructions with exact input per turn
+- Expected output/behavior per turn
+- How to verify each turn (response content, `journalctl -u iodis-orchestrator --since "2 min ago" --no-pager | grep "…"`, Metadata key via `jq`)
+- A `wscat -c ws://localhost:5000/ws` WebSocket fallback with the note: "If Discord token is unavailable, use WebSocket fallback."
+
+**Conditional — Step N: Additional Validation.** Include only if the task requires config checks (`jq` against `appconfig.json`), log checks, or other domain-specific validation beyond the standard gates.
+
+### 3. Load the playbook template
+
+Read `references/playbook-template.md` from this skill's directory. Use it as the canonical skeleton — fill in every `{placeholder}` with task-specific details from Steps 1–2.
+
+### 4. Write the playbook
+
+Write to `.smaqit/user-testing/tests/{NNN}_{slug}.md`. Derive the slug from the task title: lowercase, hyphens, drop leading article words and the task number.
+
+Rules:
+
+- `scripts/start/orchestrator-start.sh` is idempotent — it rebuilds, redeploys, and restarts the systemd unit. Never include separate `dotnet publish`, `serve_daisy.sh`, or manual systemd restart steps.
+- `scripts/health/health.sh` is the single source of truth for service health. Never check individual ports manually.
+- Every live-service E2E turn must specify: exact input, expected output/behavior, and how to verify.
+- If the playbook file already exists, ask whether to overwrite or use a different name.
+
+### 5. Report
+
+Report to the user:
+
+- Path of the created playbook
+- Sections included (Build Gate, Deploy, Live Service E2E, Additional Validation)
+- If Live Service E2E is included, list the verification methods used (Discord, WebSocket, journalctl)
+
+## Output
+
+- `.smaqit/user-testing/tests/{NNN}_{slug}.md` — complete, executable test playbook
+
+## Scope
+
+**In scope:** Creating new test playbooks for existing tasks; determining required sections from task context; including live-service E2E where applicable.
+
+**Out of scope:** Executing playbooks (`smaqit.test-start`); modifying existing playbooks (edit directly); creating task files or modifying `PLANNING.md`.
+
+## Examples
+
+**Request:** `task.test-create 058`
+
+**Agent actions:**
+1. Reads `.smaqit/tasks/058_coder_session_service.md`
+2. Determines: task touches orchestrator and Discord
+3. Loads `references/playbook-template.md`
+4. Writes `.smaqit/user-testing/tests/058_coder-session-e2e.md` with Build Gate, Deploy, Live Service E2E (Discord turns + journalctl verification), and Evidence checklist
+
+**Output:** Playbook created at `.smaqit/user-testing/tests/058_coder-session-e2e.md`. Sections: Build Gate, Deploy, Live Service E2E (Discord + journalctl).
+
+## Gotchas
+
+- `scripts/start/orchestrator-start.sh` is idempotent — it rebuilds the solution, copies to runtime, and restarts the systemd unit. Never include separate build, publish, or restart steps.
+- `scripts/health/health.sh` is the single source of truth for service health. Always use it after deploy; never check individual ports manually.
+- Discord tokens may be absent from the test environment. Always provide a `wscat`-based WebSocket fallback with the note: "If Discord token is unavailable, use WebSocket fallback."
+- Journalctl `--since` values: use `"2 min ago"` for sequential turns. Adjust if the playbook has longer delays between steps.
+- Playbook filename derives from the task title slug, not the raw task filename. Example: "021 — Assistant Multi-Turn Session Context" → `021_assistant-session-context.md`.
+
+## Completion
+
+- [ ] Task context gathered (ID, title, what it touches)
+- [ ] Required sections determined
+- [ ] Playbook template loaded from `references/playbook-template.md`
+- [ ] Complete playbook written to `.smaqit/user-testing/tests/{NNN}_{slug}.md`
+- [ ] Build Gate step present
+- [ ] Deploy step present
+- [ ] Live Service E2E step present iff task touches live services
+- [ ] No separate `dotnet publish`, `serve_daisy.sh`, or manual systemd restart anti-patterns
+- [ ] User informed of created file path
+
+## Failure Handling
+
+| Situation | Action |
+|-----------|--------|
+| Required input not provided | Request the missing information before proceeding |
+| Gathered input is ambiguous | Flag the ambiguity and ask for clarification |
+| Task ID not found in `.smaqit/tasks/` | Ask user to verify task ID; do not proceed without confirmation |
+| Playbook already exists | Ask user: overwrite or create with different name |
+| Template file not found at `references/playbook-template.md` | Use the hardcoded minimal structure from this skill's Steps section; report the missing template |
+| Task context unclear (vague description) | Infer from task file ACs and implementation steps; flag assumptions to user |

--- a/skills/smaqit.test-create/references/playbook-template.md
+++ b/skills/smaqit.test-create/references/playbook-template.md
@@ -1,0 +1,68 @@
+# Playbook Template
+
+> Canonical Markdown structure for all test playbooks. Load this when creating a new playbook via `smaqit.test-create`. Fill in `{placeholders}` with task-specific details.
+
+---
+
+```markdown
+# {Title} — E2E Test Playbook
+
+**Test ID:** {NNN}
+**Title:** {Task title}
+**Date:** YYYY-MM-DD
+**Tester:** User Testing Agent
+**Task:** {NNN}
+
+## Objectives
+{What this playbook validates — 2-4 sentences}
+
+## Prerequisites
+- {Required services, tools, access}
+- {Example: Discord bot token in appconfig.local.json (or use WebSocket fallback)}
+- {Example: wscat or Electron UI for WebSocket}
+
+## Test Steps
+
+### Step 1 — Build & Unit Test Gate
+- [ ] `dotnet build Iodis.sln --nologo --verbosity quiet` exits 0
+- [ ] `dotnet test Iodis.sln --nologo --verbosity quiet` exits 0 (zero failures)
+
+### Step 2 — Deploy & Start Orchestrator
+- [ ] `bash scripts/start/orchestrator-start.sh` — rebuilds, redeploys, restarts systemd unit
+- [ ] `bash scripts/health/health.sh` — all services report healthy
+
+### Step 3 — Live Service E2E {REMOVE THIS STEP IF TASK DOES NOT TOUCH LIVE SERVICES}
+
+{For Discord-based E2E:}
+
+- [ ] Turn 1: send "{exact Discord message}" in test channel → verify response {expected behavior}
+- [ ] Turn 2: send "{exact Discord message}" → verify response {expected behavior}
+- [ ] Verify in journald: `journalctl -u iodis-orchestrator --since "2 min ago" --no-pager | grep "{key log line}"`
+
+{For WebSocket-based E2E (fallback or primary):}
+
+- [ ] Connect: `wscat -c ws://localhost:5000/ws`
+- [ ] Turn 1: send `{"input":"{exact input}"}` → verify response contains "{expected text}"
+- [ ] Turn 2: send `{"input":"{exact input}"}` → verify response contains "{expected text}"
+- [ ] Verify in journald: `journalctl -u iodis-orchestrator --since "2 min ago" --no-pager | grep "{key log line}"`
+
+{If Discord token unavailable, add note:}
+> Note: If Discord token is unavailable, use the WebSocket fallback steps below. Connect via `wscat` instead of Discord client.
+
+### Step N — Additional Validation
+
+- [ ] {Config check, log check, or other validation}
+- [ ] {Example: verify appconfig.json entry with `jq`}
+
+## Pass/Fail Criteria
+
+**PASS** — All checkboxes are checked. All commands exit 0. Live-service responses match expected behavior.
+**FAIL** — Any checkbox unchecked. Any unexpected failure or incorrect response.
+
+## Evidence to Capture
+
+- Output of `dotnet test Iodis.sln` (pass/fail summary line)
+- Output of `bash scripts/health/health.sh` (all services line)
+- {Turn-by-turn inputs and responses for live service E2E}
+- Relevant journald log excerpts: `journalctl -u iodis-orchestrator --since "5 min ago" --no-pager | grep -E "{pattern}"`
+```

--- a/skills/smaqit.test-start/SKILL.md
+++ b/skills/smaqit.test-start/SKILL.md
@@ -2,7 +2,7 @@
 name: smaqit.test-start
 description: Start testing session with focused context. Use when beginning test workflows with the user-testing agent.
 metadata:
-  version: "0.3.0"
+  version: "0.3.1"
 agent: smaqit.user-testing
 ---
 
@@ -34,7 +34,7 @@ Read the project files that define how tests are run (whichever exist):
 Read the complete test file:
 - `.smaqit/user-testing/tests/{TEST_NUMBER}_*.md`
 
-If the test file does not exist, ask whether to create it under `.smaqit/user-testing/tests/` before proceeding.
+If the test file does not exist, ask whether to create it by invoking `smaqit.test-create` before proceeding.
 
 This file contains:
 - Test objectives


### PR DESCRIPTION
## Summary

Adds two new skills and refines the existing testing workflow to separate playbook creation, execution, and reporting into distinct responsibilities.

### New Skills

- **smaqit.test-create** (v1.0.0) — Creates structured E2E test playbooks from task files. Auto-detects live-service requirements and enforces build-gate, deploy-gate, and live-service E2E sections. Includes `references/playbook-template.md`.
- **smaqit.test-complete** (v1.0.0) — Finalizes testing sessions by verifying playbook pass/fail criteria against execution evidence and generating standardized test reports. Includes `references/report-template.md`.

### Updated

- **smaqit.test-start** (v0.3.0 → v0.3.1) — References `smaqit.test-create` when playbook is missing
- **smaqit.user-testing agent** (v0.4.1 → v0.5.0) — Phase 4 (report generation) removed; delegates to `smaqit.test-complete`
- **installer/main.go** (v1.1.3 → v1.2.0) — Skill count updated to 25
- **README.md** — Testing section expanded, skill count corrected

### Separation of Concerns

```
smaqit.test-create → smaqit.test-start → smaqit.user-testing → smaqit.test-complete
    (author)              (load)              (execute)              (report)
```