### PR TITLE
Prepare release v1.4.0

### DIFF
--- a/.github/skills/smaqit.project-diagnose/SKILL.md
+++ b/.github/skills/smaqit.project-diagnose/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: smaqit.project-diagnose
+description: Use this skill when the user asks to run a diagnostic or scan the project for gaps or requests a check on security posture, test coverage, logging setup, monitoring coverage, provisioning, or CI/CD pipelines. Scans six domains (Testing, Security, Logging, Monitoring, Provisioning, CI/CD) using a deterministic filesystem inventory and domain checklists, then produces a prioritised finding report at `.smaqit/reports/diagnose-YYYY-MM-DD.md`. Supports `--tasks` to generate smaqit tasks for new gaps, domain scoping (e.g. `project.diagnose security,logging`), and `--refresh` to overwrite an existing same-day report.
+metadata:
+  version: "1.1.0"
+compatibility: "bash, python3; Linux; no network access required"
+---
+
+# Project Diagnose
+
+## Steps
+
+### Step 1 — Load smaqit context
+
+Read these files if they exist, in order:
+
+1. `.smaqit/project-recap.md` — stack, services, deployment topology
+2. `.smaqit/references/project-research.md` — dependency versions
+3. `.smaqit/compendium.md` — prior findings (deduplication source)
+4. `.smaqit/tasks/PLANNING.md` — existing tasks (deduplication source)
+5. `specs/business/`, `specs/functional/`, `specs/stack/` — declared intent vs. live reality
+6. `.github/copilot-instructions.md` — project conventions and deployment path
+
+Extract: **Stack** (languages, runtimes, frameworks), **Infrastructure** (container runtime, web server, database), **Existing task titles**, **Known compendium findings**.
+
+### Step 1.5 — Resolve StackProfile
+
+Using the context loaded in Step 1, resolve a `StackProfile` — a key/value map used by all subsequent steps. For each field, scan the project structure and infer the value from what is actually present; do not assume a specific stack or layout:
+
+| Field | What to look for | Fallback |
+|-------|-----------------|----------|
+| `backend_dir` | Directory containing a server-side package manifest, build descriptor, or primary entrypoint | `src/`, `.` |
+| `frontend_dir` | Directory containing a UI framework manifest or configuration (a dependency on a frontend framework is the signal) | `client/`, `web/` |
+| `backend_lang` | Infer from the package manifest or build descriptor found in `backend_dir` | `unknown` |
+| `frontend_lang` | Infer from the presence of a TypeScript config; otherwise assume JavaScript | `unknown` |
+| `test_backend_patterns` | Derive from `backend_lang`: use the idiomatic test file naming convention for that language and its standard test runner | `*test*` |
+| `test_frontend_patterns` | Derive from `frontend_lang` and the test runner declared in the frontend manifest | `*test*,*spec*` |
+| `vendor_excludes` | Derive from `backend_lang`: identify the standard dependency cache and build output directories that should be excluded from source scans | `vendor` |
+| `log_file` | Look for a logging module or log configuration file in `backend_dir` | `unknown` |
+| `compose_file` | Look for a container orchestration file at the project root | `none` |
+| `web_server_config` | Look for a web server or reverse proxy configuration file or directory | `none` |
+| `backup_script` | Look for a backup script in `scripts/` or at the project root | `none` |
+| `iac_dir` | Look for an infrastructure-as-code directory (provisioning, deployment, or configuration management) | `none` |
+| `ci_dir` | Look for a CI/CD configuration file or directory | `none` |
+| `secret_tool` | Look for a secrets management configuration file; if none found, record `none` | `none` |
+
+Record the resolved StackProfile. Pass it as environment variables to the inventory script in Step 2.
+
+### Step 2 — Run inventory script
+
+Set StackProfile fields as environment variables, then run:
+
+```bash
+DIAG_BACKEND_DIR="<backend_dir>" \
+DIAG_FRONTEND_DIR="<frontend_dir>" \
+DIAG_BACKEND_LANG="<backend_lang>" \
+DIAG_TEST_BACKEND_PATTERNS="<test_backend_patterns>" \
+DIAG_TEST_FRONTEND_PATTERNS="<test_frontend_patterns>" \
+DIAG_VENDOR_EXCLUDES="<vendor_excludes>" \
+DIAG_LOG_FILE="<log_file>" \
+DIAG_COMPOSE_FILE="<compose_file>" \
+DIAG_BACKUP_SCRIPT="<backup_script>" \
+bash .github/skills/smaqit.project-diagnose/scripts/diagnose-inventory.sh
+```
+
+Captures: test file counts, test config presence, non-smaqit CI workflows, log handler type/class, log volume mount, container service logging and healthcheck status, backup script path value, systemd unit presence, env keys, secrets tool config.
+
+**Fallback**: if the script fails, read source files directly to gather equivalent facts. Log warning in the report header: "Inventory script unavailable — using manual file inspection."
+
+### Step 3 — Domain scan loop
+
+For each in-scope domain, load the checklist from `assets/checklists/<domain>.md`. Each check specifies only the **Pass Condition** — what constitutes a pass. Use the following approach to determine what to inspect:
+
+1. **Use StackProfile fields** (resolved in Step 1.5) to locate the relevant directory or file category (backend source dir, compose file, log file, backup script, CI config dir, etc.)
+2. **Run targeted directory scans** as needed (e.g. `find`, `grep`, `ls`) to discover the concrete files matching each role
+3. **Use inventory JSON** (from Step 2) for facts already collected (test counts, handler type, service lists, backup flags, etc.) — these do not require re-scanning
+4. **Assign severity** using `assets/SEVERITY_GUIDE.md` based on the nature and impact of each failing check
+
+Record each check as **Pass**, **Fail**, or **N/A** (not applicable to this stack).
+
+**Load the relevant checklist file before scanning each domain:**
+
+| Domain | Checklist |
+|--------|-----------|
+| Testing | `assets/checklists/testing.md` |
+| Security | `assets/checklists/security.md` |
+| Logging | `assets/checklists/logging.md` |
+| Monitoring | `assets/checklists/monitoring.md` |
+| Provisioning | `assets/checklists/provisioning.md` |
+| CI/CD | `assets/checklists/cicd.md` |
+
+### Step 4 — Severity classification
+
+Read `assets/SEVERITY_GUIDE.md` before classifying any finding. Apply to each failing check:
+
+- **P1** — exploitable without authentication, data loss risk, or blocks production launch
+- **P2** — operational risk, reliability degradation, or authenticated escalation vector
+- **P3** — quality/maintainability debt; no immediate runtime impact
+- **P4** — nice-to-have; future-proofing with no current operational need
+
+### Step 5 — Deduplicate
+
+For each failing check:
+
+1. Semantically compare against PLANNING.md task titles → mark as **Already Tracked**
+2. Semantically compare against compendium.md answers → mark as **Known Finding**
+3. All remaining findings are **New**
+
+Deduplication is semantic, not string-equality. "Fix session cookie secure flag" and "Enable COOKIE_SECURE in production" are the same finding.
+
+Report all findings regardless of dedup status. Only **New** findings are eligible for task creation.
+
+### Step 6 — Write report
+
+Output path: `.smaqit/reports/diagnose-YYYY-MM-DD.md`
+
+If the file exists and `--refresh` is not set: compare new findings against the existing file. If identical, output "No new findings since last diagnose run (YYYY-MM-DD)." and stop.
+
+Otherwise, write the report using `assets/REPORT_TEMPLATE.md` as the structure. The report must include:
+- Run metadata: date, domains scanned, total checks run, finding counts by severity
+- Executive summary table: domain × severity counts
+- Per-domain findings table: severity | check | affected file | recommendation | status
+- Priority matrix: P1–P4 ordered list with dependency hints
+- Already-tracked cross-reference: findings mapped to existing task IDs
+
+### Step 7 — Create tasks (only with `--tasks` flag)
+
+For each New finding meeting `--min-severity` threshold (default: all):
+
+1. Derive a task title from the finding description
+2. Re-check PLANNING.md to confirm no equivalent task was just added
+3. Invoke `smaqit.task-create` with the recommendation as the task description
+
+Report: "N tasks created for new findings."
+
+### Step 8 — Update compendium
+
+For each New finding with sufficient detail to form a useful Q&A pair, add to `.smaqit/compendium.md`:
+- Category: Security, Operations, or Architecture
+- Question: the gap as a question ("Does the backend enforce X?")
+- Answer: the finding and recommendation
+
+Report: "Compendium updated — N entries added."
+
+## Output
+
+| Artifact | Path | Condition |
+|----------|------|-----------|
+| Diagnose report | `.smaqit/reports/diagnose-YYYY-MM-DD.md` | Always |
+| Task files | `.smaqit/tasks/NNN_*.md` | Only with `--tasks` |
+| Compendium update | `.smaqit/compendium.md` | Only for new findings |
+
+## Scope
+
+**In scope:** Structural SDLC gaps (missing test infrastructure, CI pipelines, log configuration, health endpoints, backup coverage, secrets handling), code-level security patterns at system boundaries (auth endpoints, Pydantic models, cookie/header config), configuration gaps (missing env vars, misconfigured Docker services).
+
+**Out of scope:** Runtime probing (no live HTTP calls to the running application), CVE/dependency vulnerability scanning (use `smaqit.utils.triage-issues`), business logic correctness or functional completeness, performance analysis.
+
+## Examples
+
+### Example 1 — Full scan, report only
+
+**Input:** `project.diagnose`
+
+**Output:** `.smaqit/reports/diagnose-2026-05-20.md` with 6 domain sections, 20 findings (P1: 6, P2: 7, P3: 5, P4: 2). No tasks created. Console: "Diagnose complete — 20 findings across 6 domains. Report: .smaqit/reports/diagnose-2026-05-20.md"
+
+### Example 2 — Scoped scan with task generation
+
+**Input:** `project.diagnose security --tasks`
+
+**Output:** `.smaqit/reports/diagnose-2026-05-20.md` (security domain only, 6 findings). 4 new tasks created (2 already tracked in PLANNING.md). Console: "Diagnose complete — 6 security findings. 4 tasks created."
+
+### Example 3 — Re-run on fully-tasked project
+
+**Input:** `project.diagnose`
+
+**Output:** Existing report read; all findings match PLANNING.md tasks. Console: "No new findings — all 20 gaps already tracked. Report unchanged."
+
+## Gotchas
+
+- **Exclude vendor directories from test file discovery** — use StackProfile `vendor_excludes` to suppress false positives (e.g. Python `.venv`, Node `node_modules`, Go `vendor`, Java `target`)
+- **Security analysis requires reading the request schema layer, not just route decorators** — privilege escalation vulnerabilities live in the model/DTO/schema definitions (e.g. Pydantic model fields, Zod schemas, class-validator DTOs), which are invisible from route signatures alone
+- **Container healthchecks and application `/health` endpoints are independent gaps** — a service can have a container-level healthcheck without a real HTTP health route, and vice versa; both must be checked separately
+- **Backup script path correctness requires cross-referencing** — compare any hardcoded deployment path in the backup script against the actual path declared in project documentation (`project-recap.md`, `copilot-instructions.md`, or equivalent)
+- **Log persistence requires both**: a rotating log handler in the application AND a volume/mount mapping log output outside the container; either alone is insufficient
+- **CI/CD gap check**: the CI dir may contain smaqit framework workflows — exclude files whose name or top-level comment contains `smaqit`; report only application-specific build/test/scan workflows
+- **Cookie/session security flags are production-context findings** — a hardcoded insecure default that is overridable by env var is the gap; look for the fallback pattern (`os.environ.get("VAR", insecure_default)`), not just the current runtime value
+- **Deduplication is semantic, not string-equality** — "Fix session cookie secure flag" and "Enable COOKIE_SECURE in production" are the same finding; use meaning-based comparison
+- **StackProfile fields marked `unknown` do not skip the domain** — apply the checklist using inference and flag N/A for individual checks whose file cannot be located
+
+## Completion
+
+- [ ] All in-scope domain checklists applied and results recorded
+- [ ] Report written to `.smaqit/reports/diagnose-YYYY-MM-DD.md`
+- [ ] All findings include severity, affected file, and recommendation
+- [ ] Deduplication performed: no task created for an already-tracked gap
+- [ ] Compendium updated with new findings
+
+## Failure Handling
+
+| Situation | Action |
+|-----------|--------|
+| Required input not provided | Request the missing information before proceeding |
+| Gathered input is ambiguous | Flag the ambiguity and ask for clarification |
+| Subagent invocation fails | Report the failure with context; do not silently retry |
+| Output artifact already exists | Confirm with user before overwriting |
+| Inventory script missing or fails | Fall back to manual file inspection; log warning in report header |
+| A domain's source files are absent | Mark all checks for that domain as N/A; note in report |
+| PLANNING.md missing | Treat as empty; all findings are New |
+| compendium.md missing | Treat as empty; create it on first write |
+| `--tasks` requested but `smaqit.task-create` fails | Log failure in report; continue with remaining findings |

--- a/.github/skills/smaqit.project-diagnose/assets/REPORT_TEMPLATE.md
+++ b/.github/skills/smaqit.project-diagnose/assets/REPORT_TEMPLATE.md
@@ -1,0 +1,117 @@
+# Project Diagnose Report — {{DATE}}
+
+## Run Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | {{DATE}} |
+| Domains Scanned | {{DOMAINS}} |
+| Total Checks Run | {{TOTAL_CHECKS}} |
+| Total Findings | {{TOTAL_FINDINGS}} |
+| P1 — Critical | {{P1_COUNT}} |
+| P2 — High | {{P2_COUNT}} |
+| P3 — Medium | {{P3_COUNT}} |
+| P4 — Low | {{P4_COUNT}} |
+
+> Inventory script: {{INVENTORY_STATUS}}
+
+---
+
+## Executive Summary
+
+| Domain | Total | P1 | P2 | P3 | P4 |
+|--------|-------|----|----|----|----|
+| Testing | {{TEST_TOTAL}} | {{TEST_P1}} | {{TEST_P2}} | {{TEST_P3}} | {{TEST_P4}} |
+| Security | {{SEC_TOTAL}} | {{SEC_P1}} | {{SEC_P2}} | {{SEC_P3}} | {{SEC_P4}} |
+| Logging | {{LOG_TOTAL}} | {{LOG_P1}} | {{LOG_P2}} | {{LOG_P3}} | {{LOG_P4}} |
+| Monitoring | {{MON_TOTAL}} | {{MON_P1}} | {{MON_P2}} | {{MON_P3}} | {{MON_P4}} |
+| Provisioning | {{PRV_TOTAL}} | {{PRV_P1}} | {{PRV_P2}} | {{PRV_P3}} | {{PRV_P4}} |
+| CI/CD | {{CICD_TOTAL}} | {{CICD_P1}} | {{CICD_P2}} | {{CICD_P3}} | {{CICD_P4}} |
+
+---
+
+## Findings: Testing
+
+| Severity | Check | Affected File | Recommendation | Status |
+|----------|-------|---------------|----------------|--------|
+| {{SEV}} | {{CHECK}} | {{FILE}} | {{REC}} | {{STATUS}} |
+
+---
+
+## Findings: Security
+
+| Severity | Check | Affected File | Recommendation | Status |
+|----------|-------|---------------|----------------|--------|
+| {{SEV}} | {{CHECK}} | {{FILE}} | {{REC}} | {{STATUS}} |
+
+---
+
+## Findings: Logging
+
+| Severity | Check | Affected File | Recommendation | Status |
+|----------|-------|---------------|----------------|--------|
+| {{SEV}} | {{CHECK}} | {{FILE}} | {{REC}} | {{STATUS}} |
+
+---
+
+## Findings: Monitoring
+
+| Severity | Check | Affected File | Recommendation | Status |
+|----------|-------|---------------|----------------|--------|
+| {{SEV}} | {{CHECK}} | {{FILE}} | {{REC}} | {{STATUS}} |
+
+---
+
+## Findings: Provisioning
+
+| Severity | Check | Affected File | Recommendation | Status |
+|----------|-------|---------------|----------------|--------|
+| {{SEV}} | {{CHECK}} | {{FILE}} | {{REC}} | {{STATUS}} |
+
+---
+
+## Findings: CI/CD
+
+| Severity | Check | Affected File | Recommendation | Status |
+|----------|-------|---------------|----------------|--------|
+| {{SEV}} | {{CHECK}} | {{FILE}} | {{REC}} | {{STATUS}} |
+
+---
+
+## Priority Matrix
+
+### P1 — Critical
+
+<!-- List each P1 finding with dependency hints -->
+1. {{FINDING}} — depends on: {{DEPENDENCY_HINTS}}
+
+### P2 — High
+
+<!-- List each P2 finding -->
+1. {{FINDING}}
+
+### P3 — Medium
+
+<!-- List each P3 finding -->
+1. {{FINDING}}
+
+### P4 — Low
+
+<!-- List each P4 finding -->
+1. {{FINDING}}
+
+---
+
+## Already-Tracked Cross-Reference
+
+| Finding | Task ID | Task Title |
+|---------|---------|------------|
+| {{FINDING}} | {{TASK_ID}} | {{TASK_TITLE}} |
+
+---
+
+## Known Findings (Compendium)
+
+| Finding | Compendium Category | Notes |
+|---------|---------------------|-------|
+| {{FINDING}} | {{CATEGORY}} | {{NOTES}} |

--- a/.github/skills/smaqit.project-diagnose/assets/SEVERITY_GUIDE.md
+++ b/.github/skills/smaqit.project-diagnose/assets/SEVERITY_GUIDE.md
@@ -1,0 +1,104 @@
+# Severity Guide — smaqit.project-diagnose
+
+Classify each failing check using the four-tier model below. Apply top-down: assign the highest tier that matches.
+
+---
+
+## P1 — Critical
+
+**Definition:** Exploitable without authentication, presents a data loss risk, or blocks production launch.
+
+**Rules:**
+- An unauthenticated attacker can exploit the gap directly (no credentials required)
+- Hardcoded credentials, secret keys, or tokens appear in source code or image layers
+- Authentication or authorisation is absent on a sensitive endpoint
+- Production deployment is blocked: a required env var has no default and is undocumented
+- The backup system is non-functional: the primary database has no backup, or backups consistently fail
+
+**Examples:**
+
+| Finding | Why P1 |
+|---------|--------|
+| `RegisterRequest.role: Optional[str] = None` — caller controls their own role at registration | Unauthenticated privilege escalation: any user can self-assign admin |
+| `SECRET_KEY = "dev_secret"` hardcoded in `config.py` | Anyone reading the source can forge session tokens |
+| No backup covers the production PostgreSQL database | Any disk failure or accidental drop is unrecoverable |
+| Auth endpoint reachable over plain HTTP in nginx config | Login credentials transmitted in cleartext |
+| CORS `allow_origins=["*"]` on an API that issues session cookies | Cross-origin requests can harvest authenticated sessions |
+
+---
+
+## P2 — High
+
+**Definition:** Operational risk that degrades reliability or enables an authenticated user to escalate privileges.
+
+**Rules:**
+- A logged-in user can elevate their privileges through a code pattern
+- Log files are unbounded and will fill the disk under normal production load
+- Health or readiness endpoints are absent (load balancer or Docker cannot detect failures)
+- No rate limiting on authentication endpoints (brute force is unimpeded)
+- Cookie security flags (`Secure`, `HttpOnly`, `SameSite`) are missing
+- A critical data volume (vector index, object store) is not covered by backup
+
+**Examples:**
+
+| Finding | Why P2 |
+|---------|--------|
+| `FileHandler` with no rotation used in `backend/logger.py` | Logs grow unbounded; disk fill kills the service |
+| Session cookie lacks `HttpOnly` flag | XSS can steal session tokens from the browser |
+| No `/health` route in `backend/main.py` | Docker and nginx cannot detect backend failures; crashed container goes unnoticed |
+| No rate limiting on `/auth/login` | Brute-force credential attacks succeed without detection |
+| Milvus vector data volumes absent from `backup.sh` | Vector index is unrecoverable after disk failure |
+| No Docker `logging:` driver config with size limits | Container logs rotate at Docker default (unlimited); disk fills silently |
+
+---
+
+## P3 — Medium
+
+**Definition:** Quality or maintainability debt; the system functions correctly today but regressions are not caught automatically.
+
+**Rules:**
+- No test files or test runner configuration exists
+- CI pipeline is absent (builds and tests must be run manually)
+- No infrastructure-as-code (IaC); provisioning is manual but currently working
+- Security scanning absent from CI (vulnerability discovery is delayed, not impossible)
+- Backup exists but covers the wrong path (produces empty output)
+
+**Examples:**
+
+| Finding | Why P3 |
+|---------|--------|
+| Zero test files in `backend/` | Regressions are not caught; production bugs ship undetected |
+| No `[tool.pytest.ini_options]` in `pyproject.toml` | Test runs are inconsistent; no coverage threshold enforced |
+| No CI workflow for the project (only smaqit scaffolding workflows present) | Builds and tests must be run manually on every change |
+| No `pip-audit` or `npm audit` step in CI | Known CVEs in dependencies are discovered late |
+| `backup.sh` APP_DIR points to a path that does not match the deployed location | Backup runs without errors but produces empty or mismatched files |
+
+---
+
+## P4 — Low
+
+**Definition:** Nice-to-have improvements or future-proofing with no current operational impact.
+
+**Rules:**
+- Feature is only needed when a supporting infrastructure component is added
+- Improvement applies at scale, not at current deployment size
+- Structural or documentation preference, not a functional requirement
+- Defence-in-depth measure where the primary attack vector does not currently exist
+
+**Examples:**
+
+| Finding | Why P4 |
+|---------|--------|
+| No `/metrics` endpoint when no Prometheus server is deployed | Only required when the observability stack is added |
+| NGINX uses `combined` log format instead of structured JSON | Useful for log aggregation tools not currently in use |
+| No `SameSite=Strict` on cookies when no cross-site auth flow exists | Defence-in-depth with no active attack surface |
+| No `dependabot.yml` for automated dependency updates | Good practice; no current exposure beyond manual updates |
+| No SOPS encryption when secrets are managed locally on a single node | Useful when secrets management is centralised or multi-operator |
+
+---
+
+## Precedence Notes
+
+- If a finding matches both P1 and P2 (e.g., unauthenticated endpoint with no rate limiting), assign **P1**.
+- Evaluate `COOKIE_SECURE` by the **code default**, not the `.env` file — the hardcoded default is what ships to production if the env var is unset.
+- Distinguish a configuration gap (P2/P3) from an active exploitation vector (P1): a missing rate limit is P2; a missing authentication check is P1.

--- a/.github/skills/smaqit.project-diagnose/assets/checklists/cicd.md
+++ b/.github/skills/smaqit.project-diagnose/assets/checklists/cicd.md
@@ -1,0 +1,14 @@
+# CI/CD Checklist
+
+8 checks for automated build, test, and security pipeline coverage.
+
+| Check | Pass Condition |
+|-------|----------------|
+| CI configuration present | Inventory `ci_workflows.ci_dir` is not `"none"` — a CI config directory or file exists |
+| Non-smaqit project workflow files present | Inventory `ci_workflows.count` > 0 — at least one workflow whose name and header do not reference `smaqit` |
+| CI has a lint gate | Lint step present in at least one non-smaqit workflow |
+| CI has a backend test gate | Backend test runner invoked in at least one non-smaqit workflow |
+| CI has a frontend test gate | Frontend test runner invoked in at least one non-smaqit workflow |
+| CI has a security / dependency scan | Dependency or container image vulnerability scan present in at least one workflow |
+| CI has a container build gate | Container image build step present (ensures the image builds cleanly before merge) |
+| Dependency update automation configured | `dependabot.yml` with relevant package ecosystems, OR Renovate config present |

--- a/.github/skills/smaqit.project-diagnose/assets/checklists/logging.md
+++ b/.github/skills/smaqit.project-diagnose/assets/checklists/logging.md
@@ -1,0 +1,16 @@
+# Logging Checklist
+
+10 checks for log configuration, persistence, and observability.
+
+| Check | Pass Condition |
+|-------|----------------|
+| Log handler is rotating (not plain file/stream) | Inventory `logging.handler_type` is `"rotating"`; plain file or stream handler is a fail |
+| Log files persisted via volume mount | Inventory `logging.volume_mount` is `true` — a log directory is mounted into the backend container |
+| `LOG_LEVEL` env var present in `.env.example` | `LOG_LEVEL` key present in the env example file |
+| Request correlation ID middleware present | Middleware injects a unique request ID per request that propagates into log records |
+| Container log driver configured for backend | Inventory `container.services_with_logging` includes the backend service |
+| Container log `max-size` limit set for backend | `max-size` option set under the backend service logging config |
+| Container log `max-file` limit set for backend | `max-file` option set under the backend service logging config |
+| Web server access log format is structured | Custom structured log format defined (not default `combined`); JSON or key=value preferred |
+| Web server error log level configured explicitly | Error log directive present with an explicit severity level |
+| Log formatter outputs structured fields | Formatter produces structured records including `timestamp`, `level`, `logger`, and `message` |

--- a/.github/skills/smaqit.project-diagnose/assets/checklists/monitoring.md
+++ b/.github/skills/smaqit.project-diagnose/assets/checklists/monitoring.md
@@ -1,0 +1,14 @@
+# Monitoring Checklist
+
+8 checks for runtime observability and failure detection.
+
+| Check | Pass Condition |
+|-------|----------------|
+| `/health` HTTP endpoint present | Route exists and returns 2xx with a basic status payload |
+| `/ready` HTTP endpoint present | Route exists and probes downstream dependencies (DB, data store) before returning 200 |
+| `/metrics` endpoint or instrumentation present | Metrics endpoint registered OR Prometheus/OpenMetrics middleware active |
+| Metrics instrumentation library in dependencies | Instrumentation library declared in the backend package manifest |
+| Container `healthcheck` present on backend service | Inventory `container.services_with_healthcheck` includes the backend service |
+| Container `healthcheck` present on frontend service | Inventory `container.services_with_healthcheck` includes the frontend service |
+| Container `healthcheck` present on web server service | Inventory `container.services_with_healthcheck` includes the web server service |
+| Alerting configuration exists | Alerting config file present (Alertmanager, Grafana, etc.), or deployment docs include an escalation procedure |

--- a/.github/skills/smaqit.project-diagnose/assets/checklists/provisioning.md
+++ b/.github/skills/smaqit.project-diagnose/assets/checklists/provisioning.md
@@ -1,0 +1,16 @@
+# Provisioning Checklist
+
+10 checks for infrastructure repeatability, backup coverage, and secrets management.
+
+| Check | Pass Condition |
+|-------|----------------|
+| IaC present (Ansible, Terraform, or equivalent) | At least one IaC file present that describes the deployment environment |
+| Systemd unit for autostart present | Inventory `provisioning.systemd_unit` is `true` — a `.service` unit file targets the compose stack or application |
+| Backup script deployment path matches actual deployment | The hardcoded path variable in the backup script matches the path documented in project materials |
+| Backup script covers database | Inventory `backup.covers_database` is `true` — a database dump utility is invoked |
+| Backup script covers `.env` / secrets | Inventory `backup.covers_config` is `true` — `.env` or equivalent config file is included |
+| Backup script covers application-specific config | Application-specific configuration (e.g. agent config export, settings dump) exported or backed up |
+| Backup script covers data volumes | Inventory `backup.covers_volumes` is `true` — data volumes or external service data directories included |
+| Backup rotation configured | Old backup directories pruned automatically (e.g. `find ... -mtime`, `rm` of aged backups) |
+| Secrets at rest are encrypted | Inventory `provisioning.secret_tool` is not `"none"` (e.g. SOPS, Ansible Vault, HashiCorp Vault) |
+| First-deploy / onboarding documentation exists | Onboarding or first-deploy documentation present and references current stack components |

--- a/.github/skills/smaqit.project-diagnose/assets/checklists/security.md
+++ b/.github/skills/smaqit.project-diagnose/assets/checklists/security.md
@@ -1,0 +1,20 @@
+# Security Checklist
+
+14 checks for security posture at system boundaries.
+
+| Check | Pass Condition |
+|-------|----------------|
+| Caller-supplied `role` in registration schema | `role` field absent from the inbound request schema, OR field is not caller-settable (hardcoded server-side, not accepted from request body) |
+| Role field has no exploitable default | If `role` field exists, default must be hardcoded to an unprivileged value (e.g. `"user"`); `null`/`None` or missing default is a fail |
+| `SECRET_KEY` / `AUTH_SECRET` has no hardcoded fallback | No hardcoded fallback string; key is required and raises an error if absent |
+| `COOKIE_SECURE` defaults to `True` | Default is `True`/`Secure`, or the env var is required with no fallback |
+| Cookie `HttpOnly` flag enabled | `httponly=True` (or `HttpOnly` header directive) present on auth cookies |
+| Cookie `SameSite` attribute set | `samesite="lax"` or `"strict"` (or `SameSite=Lax/Strict` header) present |
+| Rate limiting middleware present | Rate limiting middleware registered on the application |
+| Rate limiting applied to auth endpoints | At least the login route has a rate limit decorator or is covered by a global limiter |
+| CSRF protection or CORS restricted to known origins | `allow_origins` does not include `"*"` on a state-modifying API; or CSRF token middleware present |
+| Local login flag enforced in login route | Login route returns 403/disabled when the local login feature flag is disabled; flag is not silently ignored |
+| File upload validates MIME type | MIME type checked against an allowlist before processing |
+| File upload validates file size | Size limit enforced before processing |
+| File path operations use safe join | Paths constructed with safe join + realpath check, or UUID-based storage keys used (no raw user-supplied filenames in paths) |
+| Web server adds security response headers | At least `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy` headers present |

--- a/.github/skills/smaqit.project-diagnose/assets/checklists/testing.md
+++ b/.github/skills/smaqit.project-diagnose/assets/checklists/testing.md
@@ -1,0 +1,18 @@
+# Testing Checklist
+
+12 checks for test infrastructure completeness.
+
+| Check | Pass Condition |
+|-------|----------------|
+| Backend test files exist | Count > 0 |
+| Frontend test files exist | Count > 0 |
+| Backend test runner configured | Language-specific runner config present (e.g. `[tool.pytest]`, `jest.config.*`, Maven Surefire, `go test`) |
+| Backend test fixtures / setup file present | Fixture or setup file present for the detected language (e.g. `conftest.py`, `testify`, `spec_helper.rb`) |
+| Frontend test runner configured | Test runner config present (e.g. `vitest.config.*`, `jest.config.*`) |
+| Backend test coverage configured | Coverage reporting configured in package manifest or dedicated coverage config |
+| Backend coverage threshold set | Coverage threshold configured and non-zero |
+| Frontend test coverage configured | Coverage reporter configured in frontend package manifest or test runner config |
+| CI workflow runs backend tests | Backend test runner invoked in at least one non-smaqit workflow |
+| CI workflow runs frontend tests | Frontend test runner invoked in at least one non-smaqit workflow |
+| Tests do not import production `.env` | No direct `.env` file read in test files (e.g. `load_dotenv`, `open(".env")`, `dotenv.config()`) |
+| Test isolation: no shared mutable state across modules | No session-scoped fixtures that mutate global state without explicit teardown |

--- a/.github/skills/smaqit.project-diagnose/scripts/diagnose-inventory.sh
+++ b/.github/skills/smaqit.project-diagnose/scripts/diagnose-inventory.sh
@@ -1,0 +1,418 @@
+#!/usr/bin/env bash
+# diagnose-inventory.sh — stack-agnostic workspace inventory for smaqit.project-diagnose
+#
+# Run from workspace root:
+#   bash .github/skills/smaqit.project-diagnose/scripts/diagnose-inventory.sh
+#
+# The agent sets StackProfile fields as environment variables before calling this script.
+# All variables have auto-detection fallbacks so the script is always runnable stand-alone.
+#
+# Inputs (env vars — all optional):
+#   DIAG_BACKEND_DIR             e.g. "backend"
+#   DIAG_FRONTEND_DIR            e.g. "frontend"
+#   DIAG_BACKEND_LANG            python|node|go|java|ruby|dotnet|unknown
+#   DIAG_FRONTEND_LANG           typescript|javascript|unknown
+#   DIAG_TEST_BACKEND_PATTERNS   comma-separated globs, e.g. "test_*.py,*_test.py"
+#   DIAG_TEST_FRONTEND_PATTERNS  comma-separated globs, e.g. "*.test.ts,*.test.tsx"
+#   DIAG_VENDOR_EXCLUDES         comma-separated dirs to prune, e.g. ".venv,node_modules"
+#   DIAG_LOG_FILE                relative path to log module, e.g. "backend/logger.py"
+#   DIAG_COMPOSE_FILE            relative path to compose file, e.g. "docker-compose.yml"
+#   DIAG_BACKUP_SCRIPT           relative path to backup script, e.g. "scripts/backup.sh"
+#
+# Output: single JSON object to stdout
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Auto-detect StackProfile fields if not provided by the agent
+# ---------------------------------------------------------------------------
+
+# backend_dir
+DIAG_BACKEND_DIR="${DIAG_BACKEND_DIR:-}"
+if [ -z "$DIAG_BACKEND_DIR" ]; then
+  for d in backend src app server; do
+    if [ -d "$d" ]; then DIAG_BACKEND_DIR="$d"; break; fi
+  done
+  DIAG_BACKEND_DIR="${DIAG_BACKEND_DIR:-.}"
+fi
+
+# frontend_dir
+DIAG_FRONTEND_DIR="${DIAG_FRONTEND_DIR:-}"
+if [ -z "$DIAG_FRONTEND_DIR" ]; then
+  for d in frontend client web ui; do
+    if [ -d "$d" ] && [ -f "$d/package.json" ]; then DIAG_FRONTEND_DIR="$d"; break; fi
+  done
+fi
+
+# backend_lang
+DIAG_BACKEND_LANG="${DIAG_BACKEND_LANG:-}"
+if [ -z "$DIAG_BACKEND_LANG" ]; then
+  if [ -f "$DIAG_BACKEND_DIR/pyproject.toml" ] || [ -f "$DIAG_BACKEND_DIR/requirements.txt" ] || [ -f "pyproject.toml" ]; then
+    DIAG_BACKEND_LANG="python"
+  elif [ -f "go.mod" ] || [ -f "$DIAG_BACKEND_DIR/go.mod" ]; then
+    DIAG_BACKEND_LANG="go"
+  elif [ -f "pom.xml" ] || [ -f "build.gradle" ]; then
+    DIAG_BACKEND_LANG="java"
+  elif [ -f "Gemfile" ]; then
+    DIAG_BACKEND_LANG="ruby"
+  elif ls *.csproj 2>/dev/null | grep -q .; then
+    DIAG_BACKEND_LANG="dotnet"
+  elif [ -f "$DIAG_BACKEND_DIR/package.json" ] || [ -f "package.json" ]; then
+    DIAG_BACKEND_LANG="node"
+  else
+    DIAG_BACKEND_LANG="unknown"
+  fi
+fi
+
+# test patterns
+DIAG_TEST_BACKEND_PATTERNS="${DIAG_TEST_BACKEND_PATTERNS:-}"
+if [ -z "$DIAG_TEST_BACKEND_PATTERNS" ]; then
+  case "$DIAG_BACKEND_LANG" in
+    python)  DIAG_TEST_BACKEND_PATTERNS="test_*.py,*_test.py" ;;
+    go)      DIAG_TEST_BACKEND_PATTERNS="*_test.go" ;;
+    java)    DIAG_TEST_BACKEND_PATTERNS="*Test.java,*Spec.java,*IT.java" ;;
+    ruby)    DIAG_TEST_BACKEND_PATTERNS="*_spec.rb,*_test.rb" ;;
+    node)    DIAG_TEST_BACKEND_PATTERNS="*.test.js,*.spec.js,*.test.ts,*.spec.ts" ;;
+    dotnet)  DIAG_TEST_BACKEND_PATTERNS="*Tests.cs,*Spec.cs" ;;
+    *)       DIAG_TEST_BACKEND_PATTERNS="*test*,*spec*" ;;
+  esac
+fi
+DIAG_TEST_FRONTEND_PATTERNS="${DIAG_TEST_FRONTEND_PATTERNS:-*.test.ts,*.test.tsx,*.spec.ts,*.spec.tsx,*.test.js,*.spec.js}"
+
+# vendor excludes
+DIAG_VENDOR_EXCLUDES="${DIAG_VENDOR_EXCLUDES:-}"
+if [ -z "$DIAG_VENDOR_EXCLUDES" ]; then
+  case "$DIAG_BACKEND_LANG" in
+    python)  DIAG_VENDOR_EXCLUDES=".venv,__pycache__" ;;
+    node)    DIAG_VENDOR_EXCLUDES="node_modules" ;;
+    go)      DIAG_VENDOR_EXCLUDES="vendor" ;;
+    java)    DIAG_VENDOR_EXCLUDES="target,build" ;;
+    ruby)    DIAG_VENDOR_EXCLUDES="vendor/bundle" ;;
+    dotnet)  DIAG_VENDOR_EXCLUDES="bin,obj" ;;
+    *)       DIAG_VENDOR_EXCLUDES="vendor,node_modules" ;;
+  esac
+fi
+
+# log file
+DIAG_LOG_FILE="${DIAG_LOG_FILE:-}"
+if [ -z "$DIAG_LOG_FILE" ]; then
+  for candidate in \
+      "$DIAG_BACKEND_DIR/logger.py" "$DIAG_BACKEND_DIR/logging.py" "$DIAG_BACKEND_DIR/log.py" \
+      "$DIAG_BACKEND_DIR/logger.ts" "$DIAG_BACKEND_DIR/logger.js" \
+      "$DIAG_BACKEND_DIR/logger.go" "$DIAG_BACKEND_DIR/internal/logger/logger.go" \
+      "src/main/resources/logback.xml" "src/main/resources/log4j2.xml"; do
+    if [ -f "$candidate" ]; then DIAG_LOG_FILE="$candidate"; break; fi
+  done
+  DIAG_LOG_FILE="${DIAG_LOG_FILE:-unknown}"
+fi
+
+# compose file
+DIAG_COMPOSE_FILE="${DIAG_COMPOSE_FILE:-}"
+if [ -z "$DIAG_COMPOSE_FILE" ]; then
+  for candidate in docker-compose.yml docker-compose.yaml compose.yml compose.yaml; do
+    if [ -f "$candidate" ]; then DIAG_COMPOSE_FILE="$candidate"; break; fi
+  done
+  DIAG_COMPOSE_FILE="${DIAG_COMPOSE_FILE:-none}"
+fi
+
+# backup script
+DIAG_BACKUP_SCRIPT="${DIAG_BACKUP_SCRIPT:-}"
+if [ -z "$DIAG_BACKUP_SCRIPT" ]; then
+  for candidate in scripts/backup.sh backup.sh scripts/backup.py Makefile; do
+    if [ -f "$candidate" ]; then DIAG_BACKUP_SCRIPT="$candidate"; break; fi
+  done
+  DIAG_BACKUP_SCRIPT="${DIAG_BACKUP_SCRIPT:-none}"
+fi
+
+# ---------------------------------------------------------------------------
+# Helper: build find -not -path exclusion arguments from comma-separated list
+# ---------------------------------------------------------------------------
+build_exclude_args() {
+  local excludes="$1" args=""
+  IFS=',' read -ra parts <<< "$excludes"
+  for ex in "${parts[@]}"; do
+    ex="${ex#"${ex%%[![:space:]]*}"}"
+    args="$args -not -path '*/${ex}/*'"
+  done
+  echo "$args"
+}
+
+BACKEND_EXCLUDES=$(build_exclude_args "$DIAG_VENDOR_EXCLUDES")
+FRONTEND_EXCLUDES="-not -path '*/node_modules/*'"
+
+# ---------------------------------------------------------------------------
+# 1. Test file counts
+# ---------------------------------------------------------------------------
+count_test_files() {
+  local dir="$1" patterns="$2" excludes="$3"
+  [ ! -d "$dir" ] && echo 0 && return
+  local total=0
+  IFS=',' read -ra pats <<< "$patterns"
+  for pat in "${pats[@]}"; do
+    pat="${pat#"${pat%%[![:space:]]*}"}"
+    n=$(eval "find \"$dir\" $excludes -name \"$pat\" 2>/dev/null" | wc -l | tr -d ' ')
+    total=$((total + n))
+  done
+  echo "$total"
+}
+
+backend_tests=$(count_test_files "$DIAG_BACKEND_DIR" "$DIAG_TEST_BACKEND_PATTERNS" "$BACKEND_EXCLUDES")
+frontend_tests=0
+if [ -n "$DIAG_FRONTEND_DIR" ] && [ -d "$DIAG_FRONTEND_DIR" ]; then
+  frontend_tests=$(count_test_files "$DIAG_FRONTEND_DIR" "$DIAG_TEST_FRONTEND_PATTERNS" "$FRONTEND_EXCLUDES")
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Test runner / config presence (language-adaptive)
+# ---------------------------------------------------------------------------
+has_backend_runner_config=false
+has_backend_test_config=false
+has_frontend_runner_config=false
+
+case "$DIAG_BACKEND_LANG" in
+  python)
+    { [ -f "$DIAG_BACKEND_DIR/pytest.ini" ] || [ -f "pytest.ini" ] || \
+      ([ -f "$DIAG_BACKEND_DIR/pyproject.toml" ] && grep -q 'tool.pytest' "$DIAG_BACKEND_DIR/pyproject.toml" 2>/dev/null); } \
+      && has_backend_runner_config=true || true
+    { [ -f "$DIAG_BACKEND_DIR/conftest.py" ] || [ -f "conftest.py" ]; } \
+      && has_backend_test_config=true || true
+    ;;
+  go)
+    grep -rq 'testify\|testing.T' "$DIAG_BACKEND_DIR" 2>/dev/null \
+      && has_backend_runner_config=true || true
+    has_backend_test_config=true
+    ;;
+  java)
+    { [ -f "pom.xml" ] && grep -q 'maven-surefire\|junit\|testng' pom.xml 2>/dev/null; } \
+      && has_backend_runner_config=true || true
+    ;;
+  node|dotnet|ruby)
+    { ls "$DIAG_BACKEND_DIR"/jest.config.* 2>/dev/null | grep -q . || \
+      ls "$DIAG_BACKEND_DIR"/vitest.config.* 2>/dev/null | grep -q .; } \
+      && has_backend_runner_config=true || true
+    ;;
+esac
+
+if [ -n "$DIAG_FRONTEND_DIR" ] && [ -d "$DIAG_FRONTEND_DIR" ]; then
+  { ls "$DIAG_FRONTEND_DIR"/vitest.config.* 2>/dev/null | grep -q . || \
+    ls "$DIAG_FRONTEND_DIR"/jest.config.* 2>/dev/null | grep -q . || \
+    ls vitest.config.* 2>/dev/null | grep -q .; } \
+    && has_frontend_runner_config=true || true
+fi
+
+# ---------------------------------------------------------------------------
+# 3. CI workflows: list non-smaqit workflow files
+# ---------------------------------------------------------------------------
+ci_files=()
+ci_dir_detected="none"
+
+if [ -d ".github/workflows" ]; then
+  ci_dir_detected=".github/workflows"
+  for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+    [ -f "$f" ] || continue
+    fname=$(basename "$f")
+    echo "$fname" | grep -qi 'smaqit' && continue || true
+    head -10 "$f" 2>/dev/null | grep -qi 'smaqit' && continue || true
+    ci_files+=("$fname")
+  done
+elif [ -f ".gitlab-ci.yml" ]; then
+  ci_dir_detected=".gitlab-ci.yml"
+  ci_files+=(".gitlab-ci.yml")
+elif [ -f "Jenkinsfile" ]; then
+  ci_dir_detected="Jenkinsfile"
+  ci_files+=("Jenkinsfile")
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Log handler type (language-adaptive)
+# ---------------------------------------------------------------------------
+log_handler="unknown"
+if [ -f "$DIAG_LOG_FILE" ]; then
+  case "$DIAG_BACKEND_LANG" in
+    python)
+      if grep -q 'RotatingFileHandler\|TimedRotatingFileHandler' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="rotating"
+      elif grep -q 'FileHandler' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="file"
+      elif grep -q 'StreamHandler\|console' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="stream"
+      fi ;;
+    node)
+      if grep -qi 'DailyRotateFile\|rotating\|winston-daily' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="rotating"
+      elif grep -qi 'transports.File\|createWriteStream' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="file"
+      else
+        log_handler="stream"
+      fi ;;
+    go)
+      if grep -qi 'lumberjack\|rotating\|rollingfile' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="rotating"
+      elif grep -qi 'os.Create\|os.OpenFile' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="file"
+      else
+        log_handler="stream"
+      fi ;;
+    java)
+      if grep -qi 'RollingFileAppender\|SizeAndTimeBasedRollingPolicy' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="rotating"
+      elif grep -qi 'FileAppender' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="file"
+      fi ;;
+    *)
+      grep -qi 'rotat' "$DIAG_LOG_FILE" 2>/dev/null && log_handler="rotating" || \
+        grep -qi 'file' "$DIAG_LOG_FILE" 2>/dev/null && log_handler="file" || true
+      ;;
+  esac
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Log volume mount
+# ---------------------------------------------------------------------------
+log_volume=false
+if [ "$DIAG_COMPOSE_FILE" != "none" ] && [ -f "$DIAG_COMPOSE_FILE" ]; then
+  grep -E '\./logs|/var/log/app' "$DIAG_COMPOSE_FILE" 2>/dev/null | grep -q . && log_volume=true || true
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Container services: logging config and healthchecks (generic, via python3)
+# ---------------------------------------------------------------------------
+all_services=""
+logging_svcs=""
+hc_svcs=""
+
+if [ "$DIAG_COMPOSE_FILE" != "none" ] && [ -f "$DIAG_COMPOSE_FILE" ]; then
+  _svc_data=$(python3 - "$DIAG_COMPOSE_FILE" << 'PYEOF'
+import re, sys, json
+content = open(sys.argv[1]).read()
+lines = content.split("\n")
+cur = None
+has_logging, has_hc, services = set(), set(), set()
+for line in lines:
+    m = re.match(r"^  (\w[\w-]*):", line)
+    if m:
+        cur = m.group(1)
+        services.add(cur)
+    if cur:
+        if re.match(r"\s{4,}logging:", line): has_logging.add(cur)
+        if re.match(r"\s{4,}healthcheck:", line): has_hc.add(cur)
+print(json.dumps({"services": sorted(services), "logging": sorted(has_logging), "healthcheck": sorted(has_hc)}))
+PYEOF
+  )
+  all_services=$(echo "$_svc_data" | python3 -c "import sys,json; d=json.load(sys.stdin); print(','.join(d['services']))" 2>/dev/null || true)
+  logging_svcs=$(echo "$_svc_data" | python3 -c "import sys,json; d=json.load(sys.stdin); print(','.join(d['logging']))" 2>/dev/null || true)
+  hc_svcs=$(echo "$_svc_data" | python3 -c "import sys,json; d=json.load(sys.stdin); print(','.join(d['healthcheck']))" 2>/dev/null || true)
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Backup script — generic coverage checks
+# ---------------------------------------------------------------------------
+backup_hardcoded_path="not found"
+backup_has_db=false
+backup_has_config=false
+backup_has_volumes=false
+
+if [ "$DIAG_BACKUP_SCRIPT" != "none" ] && [ -f "$DIAG_BACKUP_SCRIPT" ]; then
+  # Hardcoded deployment path variable
+  _raw=$(grep -E '^(APP_DIR|BACKUP_DIR|BASE_DIR|DEPLOY_DIR|PROJECT_DIR)=' "$DIAG_BACKUP_SCRIPT" 2>/dev/null | head -1 || true)
+  if [ -n "$_raw" ]; then
+    backup_hardcoded_path=$(echo "$_raw" | sed 's/^[^=]*=//' | tr -d '"' | tr -d "'")
+  fi
+  # Database backup utility
+  grep -qiE 'pg_dump|pg_dumpall|mysqldump|mongodump|sqlite3.*backup|db.backup|database.backup' \
+    "$DIAG_BACKUP_SCRIPT" 2>/dev/null && backup_has_db=true || true
+  # Config/secrets backup
+  grep -qiE '\.env|config\.yml|config\.json|secrets' \
+    "$DIAG_BACKUP_SCRIPT" 2>/dev/null && backup_has_config=true || true
+  # Volume/data directory backup
+  grep -qiE 'volumes?/|data/|tar |rsync|cp -r' \
+    "$DIAG_BACKUP_SCRIPT" 2>/dev/null && backup_has_volumes=true || true
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Systemd unit
+# ---------------------------------------------------------------------------
+systemd_unit=false
+find . -maxdepth 4 -name '*.service' 2>/dev/null | grep -q . && systemd_unit=true || true
+
+# ---------------------------------------------------------------------------
+# 9. Secrets tool
+# ---------------------------------------------------------------------------
+secret_tool="none"
+if [ -f ".sops.yaml" ] || [ -f ".sops.yml" ]; then
+  secret_tool="sops"
+elif grep -qr 'ansible-vault' deploy/ scripts/ 2>/dev/null; then
+  secret_tool="ansible-vault"
+elif [ -f ".vault-token" ] || grep -qr '"vault"' deploy/ 2>/dev/null; then
+  secret_tool="vault"
+fi
+
+# ---------------------------------------------------------------------------
+# 10. .env.example keys (field names only, no values)
+# ---------------------------------------------------------------------------
+env_keys=()
+for envfile in .env.example .env.sample .env.template; do
+  if [ -f "$envfile" ]; then
+    while IFS= read -r line; do
+      [[ "$line" =~ ^[[:space:]]*# ]] && continue || true
+      [[ "$line" =~ ^[[:space:]]*$ ]] && continue || true
+      key=$(echo "$line" | cut -d'=' -f1 | tr -d ' ')
+      [ -n "$key" ] && env_keys+=("$key") || true
+    done < "$envfile"
+    break
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Serialize and output JSON
+# ---------------------------------------------------------------------------
+ci_count="${#ci_files[@]}"
+ci_json=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1:]))" "${ci_files[@]+"${ci_files[@]}"}" 2>/dev/null || echo "[]")
+keys_json=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1:]))" "${env_keys[@]+"${env_keys[@]}"}" 2>/dev/null || echo "[]")
+
+# Convert bash true/false to Python True/False
+_py() { [ "$1" = "true" ] && echo "True" || echo "False"; }
+_py_backend_runner=$(_py "$has_backend_runner_config")
+_py_backend_test=$(_py "$has_backend_test_config")
+_py_frontend_runner=$(_py "$has_frontend_runner_config")
+_py_log_volume=$(_py "$log_volume")
+_py_backup_db=$(_py "$backup_has_db")
+_py_backup_config=$(_py "$backup_has_config")
+_py_backup_volumes=$(_py "$backup_has_volumes")
+_py_systemd=$(_py "$systemd_unit")
+
+python3 - << PYEOF
+import json
+print(json.dumps({
+    "stack_profile": {
+        "backend_dir": "${DIAG_BACKEND_DIR}",
+        "frontend_dir": "${DIAG_FRONTEND_DIR:-}",
+        "backend_lang": "${DIAG_BACKEND_LANG}",
+        "log_file": "${DIAG_LOG_FILE}",
+        "compose_file": "${DIAG_COMPOSE_FILE}",
+        "backup_script": "${DIAG_BACKUP_SCRIPT}"
+    },
+    "test_files": {"backend": ${backend_tests}, "frontend": ${frontend_tests}},
+    "test_configs": {
+        "backend_runner_config": ${_py_backend_runner},
+        "backend_test_fixtures": ${_py_backend_test},
+        "frontend_runner_config": ${_py_frontend_runner}
+    },
+    "ci_workflows": {"count": ${ci_count}, "ci_dir": "${ci_dir_detected}", "files": ${ci_json}},
+    "logging": {"handler_type": "${log_handler}", "volume_mount": ${_py_log_volume}},
+    "container": {
+        "compose_file": "${DIAG_COMPOSE_FILE}",
+        "all_services": "${all_services:-}",
+        "services_with_logging": "${logging_svcs:-}",
+        "services_with_healthcheck": "${hc_svcs:-}"
+    },
+    "backup": {
+        "script": "${DIAG_BACKUP_SCRIPT}",
+        "hardcoded_path": "${backup_hardcoded_path}",
+        "covers_database": ${_py_backup_db},
+        "covers_config": ${_py_backup_config},
+        "covers_volumes": ${_py_backup_volumes}
+    },
+    "provisioning": {"systemd_unit": ${_py_systemd}, "secret_tool": "${secret_tool}"},
+    "env_example_keys": ${keys_json}
+}, indent=2))
+PYEOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-21
+
+### Added
+- **`smaqit.project-diagnose` skill v1.1.0** — scans project structure for gaps across testing, security, logging, monitoring, provisioning, and CI/CD domains; produces a prioritised finding report with domain checklists and optional task creation (`project.diagnose`)
+
+### Changed
+- **Makefile** — added `smaqit.project-diagnose` to sync list; changed assets copy to recursive (`cp -rfL`) to support nested asset directories
+- Release version metadata updated to 1.4.0 in installer sources (`installer/main.go`, `installer/Makefile`)
+
 ## [1.2.0] - 2026-06-03
 
 ### Added
@@ -469,7 +478,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Go-based installer for cross-platform installation
 - Bash install script with version mode support
 
-[Unreleased]: https://github.com/ruifrvaz/smaqit-extensions/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/ruifrvaz/smaqit-extensions/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/ruifrvaz/smaqit-extensions/compare/v1.2.0...v1.4.0
 [1.2.0]: https://github.com/ruifrvaz/smaqit-extensions/compare/v1.1.5...v1.2.0
 [1.1.5]: https://github.com/ruifrvaz/smaqit-extensions/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/ruifrvaz/smaqit-extensions/compare/v1.1.3...v1.1.4

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ sync:
 	@echo "Syncing source files to .github/..."
 	@mkdir -p .github/agents .github/skills
 	@cp -f agents/*.md .github/agents/
-	@for skill in smaqit.session-start smaqit.session-finish smaqit.session-assess smaqit.session-title smaqit.session-recap smaqit.task-create smaqit.task-list smaqit.task-complete smaqit.task-start smaqit.test-start smaqit.project-init smaqit.project-glossary smaqit.release-analysis smaqit.release-approval smaqit.release-prepare-files smaqit.release-git-local smaqit.release-git-pr smaqit.utils.read-pdf smaqit.utils.triage-issues smaqit.project-research smaqit.project-recap smaqit.project-compendium smaqit.parity-assess; do \
+	@for skill in smaqit.session-start smaqit.session-finish smaqit.session-assess smaqit.session-title smaqit.session-recap smaqit.task-create smaqit.task-list smaqit.task-complete smaqit.task-start smaqit.test-start smaqit.project-init smaqit.project-glossary smaqit.release-analysis smaqit.release-approval smaqit.release-prepare-files smaqit.release-git-local smaqit.release-git-pr smaqit.utils.read-pdf smaqit.utils.triage-issues smaqit.project-research smaqit.project-recap smaqit.project-compendium smaqit.project-diagnose smaqit.parity-assess; do \
 		mkdir -p .github/skills/$$skill; \
 		cp -f skills/$$skill/SKILL.md .github/skills/$$skill/; \
 		if [ -d skills/$$skill/references ]; then \
@@ -14,7 +14,7 @@ sync:
 		fi; \
 		if [ -d skills/$$skill/assets ]; then \
 			mkdir -p .github/skills/$$skill/assets; \
-			cp -fL skills/$$skill/assets/* .github/skills/$$skill/assets/ 2>/dev/null || true; \
+			cp -rfL skills/$$skill/assets/* .github/skills/$$skill/assets/ 2>/dev/null || true; \
 		fi; \
 		if [ -d skills/$$skill/scripts ]; then \
 			mkdir -p .github/skills/$$skill/scripts; \

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Enhance your agentic development with streamlined session management, task track
 #### Project Management
 - **smaqit.project-init** - Bootstrap a new smaqit project by generating `.github/copilot-instructions.md` from a template
 - **smaqit.project-glossary** - Manage a per-project glossary (`list glossary`, `fetch from glossary`, `update glossary`, `remove from glossary`)
+- **smaqit.project-diagnose** - Scan project structure for gaps across testing, security, logging, monitoring, provisioning, and CI/CD domains (`project.diagnose`, `project.diagnose security --tasks`)
 - **smaqit.project-research** - Build and maintain a documentation topology map for the current project (`project.research`, `project.research [task-id]`)
 - **smaqit.project-recap** - Generate a live project dashboard from the current codebase state (`project.recap`, `project.recap --refresh`)
 - **smaqit.project-compendium** - Manage a live Q&A knowledge base (`list compendium`, `fetch from compendium`, `update compendium`, `remove from compendium`)
@@ -66,7 +67,7 @@ curl -fsSL https://raw.githubusercontent.com/ruifrvaz/smaqit-extensions/main/ins
 
 The installer copies files to your project's `.github/` directory:
 - `agents/` - 3 utility agents (release local, release PR, user-testing)
-- `skills/` - 23 workflow skills (complete implementations)
+- `skills/` - 26 workflow skills (complete implementations)
 
 ## Usage
 

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build clean test prepare
 
-VERSION ?= 1.2.0
+VERSION ?= 1.4.0
 
 prepare:
 	@echo "Preparing build environment..."

--- a/installer/main.go
+++ b/installer/main.go
@@ -25,7 +25,7 @@ var skillFiles embed.FS
 var templateFiles embed.FS
 
 // Version is set via ldflags during build: -X main.Version=$(VERSION)
-var Version = "1.2.0"
+var Version = "1.4.0"
 
 const planningTemplate = `# Task Planning
 
@@ -100,7 +100,7 @@ func printHelp() {
 	fmt.Println()
 	fmt.Println("What gets installed:")
 	fmt.Println("  .github/agents/     - 3 utility agents")
-	fmt.Println("  .github/skills/     - 22 workflow skills")
+	fmt.Println("  .github/skills/     - 26 workflow skills")
 	fmt.Println("  .smaqit/templates/  - 3 canonical templates")
 }
 

--- a/skills/smaqit.project-diagnose/SKILL.md
+++ b/skills/smaqit.project-diagnose/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: smaqit.project-diagnose
+description: Use this skill when the user asks to run a diagnostic or scan the project for gaps or requests a check on security posture, test coverage, logging setup, monitoring coverage, provisioning, or CI/CD pipelines. Scans six domains (Testing, Security, Logging, Monitoring, Provisioning, CI/CD) using a deterministic filesystem inventory and domain checklists, then produces a prioritised finding report at `.smaqit/reports/diagnose-YYYY-MM-DD.md`. Supports `--tasks` to generate smaqit tasks for new gaps, domain scoping (e.g. `project.diagnose security,logging`), and `--refresh` to overwrite an existing same-day report.
+metadata:
+  version: "1.1.0"
+compatibility: "bash, python3; Linux; no network access required"
+---
+
+# Project Diagnose
+
+## Steps
+
+### Step 1 — Load smaqit context
+
+Read these files if they exist, in order:
+
+1. `.smaqit/project-recap.md` — stack, services, deployment topology
+2. `.smaqit/references/project-research.md` — dependency versions
+3. `.smaqit/compendium.md` — prior findings (deduplication source)
+4. `.smaqit/tasks/PLANNING.md` — existing tasks (deduplication source)
+5. `specs/business/`, `specs/functional/`, `specs/stack/` — declared intent vs. live reality
+6. `.github/copilot-instructions.md` — project conventions and deployment path
+
+Extract: **Stack** (languages, runtimes, frameworks), **Infrastructure** (container runtime, web server, database), **Existing task titles**, **Known compendium findings**.
+
+### Step 1.5 — Resolve StackProfile
+
+Using the context loaded in Step 1, resolve a `StackProfile` — a key/value map used by all subsequent steps. For each field, scan the project structure and infer the value from what is actually present; do not assume a specific stack or layout:
+
+| Field | What to look for | Fallback |
+|-------|-----------------|----------|
+| `backend_dir` | Directory containing a server-side package manifest, build descriptor, or primary entrypoint | `src/`, `.` |
+| `frontend_dir` | Directory containing a UI framework manifest or configuration (a dependency on a frontend framework is the signal) | `client/`, `web/` |
+| `backend_lang` | Infer from the package manifest or build descriptor found in `backend_dir` | `unknown` |
+| `frontend_lang` | Infer from the presence of a TypeScript config; otherwise assume JavaScript | `unknown` |
+| `test_backend_patterns` | Derive from `backend_lang`: use the idiomatic test file naming convention for that language and its standard test runner | `*test*` |
+| `test_frontend_patterns` | Derive from `frontend_lang` and the test runner declared in the frontend manifest | `*test*,*spec*` |
+| `vendor_excludes` | Derive from `backend_lang`: identify the standard dependency cache and build output directories that should be excluded from source scans | `vendor` |
+| `log_file` | Look for a logging module or log configuration file in `backend_dir` | `unknown` |
+| `compose_file` | Look for a container orchestration file at the project root | `none` |
+| `web_server_config` | Look for a web server or reverse proxy configuration file or directory | `none` |
+| `backup_script` | Look for a backup script in `scripts/` or at the project root | `none` |
+| `iac_dir` | Look for an infrastructure-as-code directory (provisioning, deployment, or configuration management) | `none` |
+| `ci_dir` | Look for a CI/CD configuration file or directory | `none` |
+| `secret_tool` | Look for a secrets management configuration file; if none found, record `none` | `none` |
+
+Record the resolved StackProfile. Pass it as environment variables to the inventory script in Step 2.
+
+### Step 2 — Run inventory script
+
+Set StackProfile fields as environment variables, then run:
+
+```bash
+DIAG_BACKEND_DIR="<backend_dir>" \
+DIAG_FRONTEND_DIR="<frontend_dir>" \
+DIAG_BACKEND_LANG="<backend_lang>" \
+DIAG_TEST_BACKEND_PATTERNS="<test_backend_patterns>" \
+DIAG_TEST_FRONTEND_PATTERNS="<test_frontend_patterns>" \
+DIAG_VENDOR_EXCLUDES="<vendor_excludes>" \
+DIAG_LOG_FILE="<log_file>" \
+DIAG_COMPOSE_FILE="<compose_file>" \
+DIAG_BACKUP_SCRIPT="<backup_script>" \
+bash .github/skills/smaqit.project-diagnose/scripts/diagnose-inventory.sh
+```
+
+Captures: test file counts, test config presence, non-smaqit CI workflows, log handler type/class, log volume mount, container service logging and healthcheck status, backup script path value, systemd unit presence, env keys, secrets tool config.
+
+**Fallback**: if the script fails, read source files directly to gather equivalent facts. Log warning in the report header: "Inventory script unavailable — using manual file inspection."
+
+### Step 3 — Domain scan loop
+
+For each in-scope domain, load the checklist from `assets/checklists/<domain>.md`. Each check specifies only the **Pass Condition** — what constitutes a pass. Use the following approach to determine what to inspect:
+
+1. **Use StackProfile fields** (resolved in Step 1.5) to locate the relevant directory or file category (backend source dir, compose file, log file, backup script, CI config dir, etc.)
+2. **Run targeted directory scans** as needed (e.g. `find`, `grep`, `ls`) to discover the concrete files matching each role
+3. **Use inventory JSON** (from Step 2) for facts already collected (test counts, handler type, service lists, backup flags, etc.) — these do not require re-scanning
+4. **Assign severity** using `assets/SEVERITY_GUIDE.md` based on the nature and impact of each failing check
+
+Record each check as **Pass**, **Fail**, or **N/A** (not applicable to this stack).
+
+**Load the relevant checklist file before scanning each domain:**
+
+| Domain | Checklist |
+|--------|-----------|
+| Testing | `assets/checklists/testing.md` |
+| Security | `assets/checklists/security.md` |
+| Logging | `assets/checklists/logging.md` |
+| Monitoring | `assets/checklists/monitoring.md` |
+| Provisioning | `assets/checklists/provisioning.md` |
+| CI/CD | `assets/checklists/cicd.md` |
+
+### Step 4 — Severity classification
+
+Read `assets/SEVERITY_GUIDE.md` before classifying any finding. Apply to each failing check:
+
+- **P1** — exploitable without authentication, data loss risk, or blocks production launch
+- **P2** — operational risk, reliability degradation, or authenticated escalation vector
+- **P3** — quality/maintainability debt; no immediate runtime impact
+- **P4** — nice-to-have; future-proofing with no current operational need
+
+### Step 5 — Deduplicate
+
+For each failing check:
+
+1. Semantically compare against PLANNING.md task titles → mark as **Already Tracked**
+2. Semantically compare against compendium.md answers → mark as **Known Finding**
+3. All remaining findings are **New**
+
+Deduplication is semantic, not string-equality. "Fix session cookie secure flag" and "Enable COOKIE_SECURE in production" are the same finding.
+
+Report all findings regardless of dedup status. Only **New** findings are eligible for task creation.
+
+### Step 6 — Write report
+
+Output path: `.smaqit/reports/diagnose-YYYY-MM-DD.md`
+
+If the file exists and `--refresh` is not set: compare new findings against the existing file. If identical, output "No new findings since last diagnose run (YYYY-MM-DD)." and stop.
+
+Otherwise, write the report using `assets/REPORT_TEMPLATE.md` as the structure. The report must include:
+- Run metadata: date, domains scanned, total checks run, finding counts by severity
+- Executive summary table: domain × severity counts
+- Per-domain findings table: severity | check | affected file | recommendation | status
+- Priority matrix: P1–P4 ordered list with dependency hints
+- Already-tracked cross-reference: findings mapped to existing task IDs
+
+### Step 7 — Create tasks (only with `--tasks` flag)
+
+For each New finding meeting `--min-severity` threshold (default: all):
+
+1. Derive a task title from the finding description
+2. Re-check PLANNING.md to confirm no equivalent task was just added
+3. Invoke `smaqit.task-create` with the recommendation as the task description
+
+Report: "N tasks created for new findings."
+
+### Step 8 — Update compendium
+
+For each New finding with sufficient detail to form a useful Q&A pair, add to `.smaqit/compendium.md`:
+- Category: Security, Operations, or Architecture
+- Question: the gap as a question ("Does the backend enforce X?")
+- Answer: the finding and recommendation
+
+Report: "Compendium updated — N entries added."
+
+## Output
+
+| Artifact | Path | Condition |
+|----------|------|-----------|
+| Diagnose report | `.smaqit/reports/diagnose-YYYY-MM-DD.md` | Always |
+| Task files | `.smaqit/tasks/NNN_*.md` | Only with `--tasks` |
+| Compendium update | `.smaqit/compendium.md` | Only for new findings |
+
+## Scope
+
+**In scope:** Structural SDLC gaps (missing test infrastructure, CI pipelines, log configuration, health endpoints, backup coverage, secrets handling), code-level security patterns at system boundaries (auth endpoints, Pydantic models, cookie/header config), configuration gaps (missing env vars, misconfigured Docker services).
+
+**Out of scope:** Runtime probing (no live HTTP calls to the running application), CVE/dependency vulnerability scanning (use `smaqit.utils.triage-issues`), business logic correctness or functional completeness, performance analysis.
+
+## Examples
+
+### Example 1 — Full scan, report only
+
+**Input:** `project.diagnose`
+
+**Output:** `.smaqit/reports/diagnose-2026-05-20.md` with 6 domain sections, 20 findings (P1: 6, P2: 7, P3: 5, P4: 2). No tasks created. Console: "Diagnose complete — 20 findings across 6 domains. Report: .smaqit/reports/diagnose-2026-05-20.md"
+
+### Example 2 — Scoped scan with task generation
+
+**Input:** `project.diagnose security --tasks`
+
+**Output:** `.smaqit/reports/diagnose-2026-05-20.md` (security domain only, 6 findings). 4 new tasks created (2 already tracked in PLANNING.md). Console: "Diagnose complete — 6 security findings. 4 tasks created."
+
+### Example 3 — Re-run on fully-tasked project
+
+**Input:** `project.diagnose`
+
+**Output:** Existing report read; all findings match PLANNING.md tasks. Console: "No new findings — all 20 gaps already tracked. Report unchanged."
+
+## Gotchas
+
+- **Exclude vendor directories from test file discovery** — use StackProfile `vendor_excludes` to suppress false positives (e.g. Python `.venv`, Node `node_modules`, Go `vendor`, Java `target`)
+- **Security analysis requires reading the request schema layer, not just route decorators** — privilege escalation vulnerabilities live in the model/DTO/schema definitions (e.g. Pydantic model fields, Zod schemas, class-validator DTOs), which are invisible from route signatures alone
+- **Container healthchecks and application `/health` endpoints are independent gaps** — a service can have a container-level healthcheck without a real HTTP health route, and vice versa; both must be checked separately
+- **Backup script path correctness requires cross-referencing** — compare any hardcoded deployment path in the backup script against the actual path declared in project documentation (`project-recap.md`, `copilot-instructions.md`, or equivalent)
+- **Log persistence requires both**: a rotating log handler in the application AND a volume/mount mapping log output outside the container; either alone is insufficient
+- **CI/CD gap check**: the CI dir may contain smaqit framework workflows — exclude files whose name or top-level comment contains `smaqit`; report only application-specific build/test/scan workflows
+- **Cookie/session security flags are production-context findings** — a hardcoded insecure default that is overridable by env var is the gap; look for the fallback pattern (`os.environ.get("VAR", insecure_default)`), not just the current runtime value
+- **Deduplication is semantic, not string-equality** — "Fix session cookie secure flag" and "Enable COOKIE_SECURE in production" are the same finding; use meaning-based comparison
+- **StackProfile fields marked `unknown` do not skip the domain** — apply the checklist using inference and flag N/A for individual checks whose file cannot be located
+
+## Completion
+
+- [ ] All in-scope domain checklists applied and results recorded
+- [ ] Report written to `.smaqit/reports/diagnose-YYYY-MM-DD.md`
+- [ ] All findings include severity, affected file, and recommendation
+- [ ] Deduplication performed: no task created for an already-tracked gap
+- [ ] Compendium updated with new findings
+
+## Failure Handling
+
+| Situation | Action |
+|-----------|--------|
+| Required input not provided | Request the missing information before proceeding |
+| Gathered input is ambiguous | Flag the ambiguity and ask for clarification |
+| Subagent invocation fails | Report the failure with context; do not silently retry |
+| Output artifact already exists | Confirm with user before overwriting |
+| Inventory script missing or fails | Fall back to manual file inspection; log warning in report header |
+| A domain's source files are absent | Mark all checks for that domain as N/A; note in report |
+| PLANNING.md missing | Treat as empty; all findings are New |
+| compendium.md missing | Treat as empty; create it on first write |
+| `--tasks` requested but `smaqit.task-create` fails | Log failure in report; continue with remaining findings |

--- a/skills/smaqit.project-diagnose/assets/REPORT_TEMPLATE.md
+++ b/skills/smaqit.project-diagnose/assets/REPORT_TEMPLATE.md
@@ -1,0 +1,117 @@
+# Project Diagnose Report — {{DATE}}
+
+## Run Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | {{DATE}} |
+| Domains Scanned | {{DOMAINS}} |
+| Total Checks Run | {{TOTAL_CHECKS}} |
+| Total Findings | {{TOTAL_FINDINGS}} |
+| P1 — Critical | {{P1_COUNT}} |
+| P2 — High | {{P2_COUNT}} |
+| P3 — Medium | {{P3_COUNT}} |
+| P4 — Low | {{P4_COUNT}} |
+
+> Inventory script: {{INVENTORY_STATUS}}
+
+---
+
+## Executive Summary
+
+| Domain | Total | P1 | P2 | P3 | P4 |
+|--------|-------|----|----|----|----|
+| Testing | {{TEST_TOTAL}} | {{TEST_P1}} | {{TEST_P2}} | {{TEST_P3}} | {{TEST_P4}} |
+| Security | {{SEC_TOTAL}} | {{SEC_P1}} | {{SEC_P2}} | {{SEC_P3}} | {{SEC_P4}} |
+| Logging | {{LOG_TOTAL}} | {{LOG_P1}} | {{LOG_P2}} | {{LOG_P3}} | {{LOG_P4}} |
+| Monitoring | {{MON_TOTAL}} | {{MON_P1}} | {{MON_P2}} | {{MON_P3}} | {{MON_P4}} |
+| Provisioning | {{PRV_TOTAL}} | {{PRV_P1}} | {{PRV_P2}} | {{PRV_P3}} | {{PRV_P4}} |
+| CI/CD | {{CICD_TOTAL}} | {{CICD_P1}} | {{CICD_P2}} | {{CICD_P3}} | {{CICD_P4}} |
+
+---
+
+## Findings: Testing
+
+| Severity | Check | Affected File | Recommendation | Status |
+|----------|-------|---------------|----------------|--------|
+| {{SEV}} | {{CHECK}} | {{FILE}} | {{REC}} | {{STATUS}} |
+
+---
+
+## Findings: Security
+
+| Severity | Check | Affected File | Recommendation | Status |
+|----------|-------|---------------|----------------|--------|
+| {{SEV}} | {{CHECK}} | {{FILE}} | {{REC}} | {{STATUS}} |
+
+---
+
+## Findings: Logging
+
+| Severity | Check | Affected File | Recommendation | Status |
+|----------|-------|---------------|----------------|--------|
+| {{SEV}} | {{CHECK}} | {{FILE}} | {{REC}} | {{STATUS}} |
+
+---
+
+## Findings: Monitoring
+
+| Severity | Check | Affected File | Recommendation | Status |
+|----------|-------|---------------|----------------|--------|
+| {{SEV}} | {{CHECK}} | {{FILE}} | {{REC}} | {{STATUS}} |
+
+---
+
+## Findings: Provisioning
+
+| Severity | Check | Affected File | Recommendation | Status |
+|----------|-------|---------------|----------------|--------|
+| {{SEV}} | {{CHECK}} | {{FILE}} | {{REC}} | {{STATUS}} |
+
+---
+
+## Findings: CI/CD
+
+| Severity | Check | Affected File | Recommendation | Status |
+|----------|-------|---------------|----------------|--------|
+| {{SEV}} | {{CHECK}} | {{FILE}} | {{REC}} | {{STATUS}} |
+
+---
+
+## Priority Matrix
+
+### P1 — Critical
+
+<!-- List each P1 finding with dependency hints -->
+1. {{FINDING}} — depends on: {{DEPENDENCY_HINTS}}
+
+### P2 — High
+
+<!-- List each P2 finding -->
+1. {{FINDING}}
+
+### P3 — Medium
+
+<!-- List each P3 finding -->
+1. {{FINDING}}
+
+### P4 — Low
+
+<!-- List each P4 finding -->
+1. {{FINDING}}
+
+---
+
+## Already-Tracked Cross-Reference
+
+| Finding | Task ID | Task Title |
+|---------|---------|------------|
+| {{FINDING}} | {{TASK_ID}} | {{TASK_TITLE}} |
+
+---
+
+## Known Findings (Compendium)
+
+| Finding | Compendium Category | Notes |
+|---------|---------------------|-------|
+| {{FINDING}} | {{CATEGORY}} | {{NOTES}} |

--- a/skills/smaqit.project-diagnose/assets/SEVERITY_GUIDE.md
+++ b/skills/smaqit.project-diagnose/assets/SEVERITY_GUIDE.md
@@ -1,0 +1,104 @@
+# Severity Guide — smaqit.project-diagnose
+
+Classify each failing check using the four-tier model below. Apply top-down: assign the highest tier that matches.
+
+---
+
+## P1 — Critical
+
+**Definition:** Exploitable without authentication, presents a data loss risk, or blocks production launch.
+
+**Rules:**
+- An unauthenticated attacker can exploit the gap directly (no credentials required)
+- Hardcoded credentials, secret keys, or tokens appear in source code or image layers
+- Authentication or authorisation is absent on a sensitive endpoint
+- Production deployment is blocked: a required env var has no default and is undocumented
+- The backup system is non-functional: the primary database has no backup, or backups consistently fail
+
+**Examples:**
+
+| Finding | Why P1 |
+|---------|--------|
+| `RegisterRequest.role: Optional[str] = None` — caller controls their own role at registration | Unauthenticated privilege escalation: any user can self-assign admin |
+| `SECRET_KEY = "dev_secret"` hardcoded in `config.py` | Anyone reading the source can forge session tokens |
+| No backup covers the production PostgreSQL database | Any disk failure or accidental drop is unrecoverable |
+| Auth endpoint reachable over plain HTTP in nginx config | Login credentials transmitted in cleartext |
+| CORS `allow_origins=["*"]` on an API that issues session cookies | Cross-origin requests can harvest authenticated sessions |
+
+---
+
+## P2 — High
+
+**Definition:** Operational risk that degrades reliability or enables an authenticated user to escalate privileges.
+
+**Rules:**
+- A logged-in user can elevate their privileges through a code pattern
+- Log files are unbounded and will fill the disk under normal production load
+- Health or readiness endpoints are absent (load balancer or Docker cannot detect failures)
+- No rate limiting on authentication endpoints (brute force is unimpeded)
+- Cookie security flags (`Secure`, `HttpOnly`, `SameSite`) are missing
+- A critical data volume (vector index, object store) is not covered by backup
+
+**Examples:**
+
+| Finding | Why P2 |
+|---------|--------|
+| `FileHandler` with no rotation used in `backend/logger.py` | Logs grow unbounded; disk fill kills the service |
+| Session cookie lacks `HttpOnly` flag | XSS can steal session tokens from the browser |
+| No `/health` route in `backend/main.py` | Docker and nginx cannot detect backend failures; crashed container goes unnoticed |
+| No rate limiting on `/auth/login` | Brute-force credential attacks succeed without detection |
+| Milvus vector data volumes absent from `backup.sh` | Vector index is unrecoverable after disk failure |
+| No Docker `logging:` driver config with size limits | Container logs rotate at Docker default (unlimited); disk fills silently |
+
+---
+
+## P3 — Medium
+
+**Definition:** Quality or maintainability debt; the system functions correctly today but regressions are not caught automatically.
+
+**Rules:**
+- No test files or test runner configuration exists
+- CI pipeline is absent (builds and tests must be run manually)
+- No infrastructure-as-code (IaC); provisioning is manual but currently working
+- Security scanning absent from CI (vulnerability discovery is delayed, not impossible)
+- Backup exists but covers the wrong path (produces empty output)
+
+**Examples:**
+
+| Finding | Why P3 |
+|---------|--------|
+| Zero test files in `backend/` | Regressions are not caught; production bugs ship undetected |
+| No `[tool.pytest.ini_options]` in `pyproject.toml` | Test runs are inconsistent; no coverage threshold enforced |
+| No CI workflow for the project (only smaqit scaffolding workflows present) | Builds and tests must be run manually on every change |
+| No `pip-audit` or `npm audit` step in CI | Known CVEs in dependencies are discovered late |
+| `backup.sh` APP_DIR points to a path that does not match the deployed location | Backup runs without errors but produces empty or mismatched files |
+
+---
+
+## P4 — Low
+
+**Definition:** Nice-to-have improvements or future-proofing with no current operational impact.
+
+**Rules:**
+- Feature is only needed when a supporting infrastructure component is added
+- Improvement applies at scale, not at current deployment size
+- Structural or documentation preference, not a functional requirement
+- Defence-in-depth measure where the primary attack vector does not currently exist
+
+**Examples:**
+
+| Finding | Why P4 |
+|---------|--------|
+| No `/metrics` endpoint when no Prometheus server is deployed | Only required when the observability stack is added |
+| NGINX uses `combined` log format instead of structured JSON | Useful for log aggregation tools not currently in use |
+| No `SameSite=Strict` on cookies when no cross-site auth flow exists | Defence-in-depth with no active attack surface |
+| No `dependabot.yml` for automated dependency updates | Good practice; no current exposure beyond manual updates |
+| No SOPS encryption when secrets are managed locally on a single node | Useful when secrets management is centralised or multi-operator |
+
+---
+
+## Precedence Notes
+
+- If a finding matches both P1 and P2 (e.g., unauthenticated endpoint with no rate limiting), assign **P1**.
+- Evaluate `COOKIE_SECURE` by the **code default**, not the `.env` file — the hardcoded default is what ships to production if the env var is unset.
+- Distinguish a configuration gap (P2/P3) from an active exploitation vector (P1): a missing rate limit is P2; a missing authentication check is P1.

--- a/skills/smaqit.project-diagnose/assets/checklists/cicd.md
+++ b/skills/smaqit.project-diagnose/assets/checklists/cicd.md
@@ -1,0 +1,14 @@
+# CI/CD Checklist
+
+8 checks for automated build, test, and security pipeline coverage.
+
+| Check | Pass Condition |
+|-------|----------------|
+| CI configuration present | Inventory `ci_workflows.ci_dir` is not `"none"` — a CI config directory or file exists |
+| Non-smaqit project workflow files present | Inventory `ci_workflows.count` > 0 — at least one workflow whose name and header do not reference `smaqit` |
+| CI has a lint gate | Lint step present in at least one non-smaqit workflow |
+| CI has a backend test gate | Backend test runner invoked in at least one non-smaqit workflow |
+| CI has a frontend test gate | Frontend test runner invoked in at least one non-smaqit workflow |
+| CI has a security / dependency scan | Dependency or container image vulnerability scan present in at least one workflow |
+| CI has a container build gate | Container image build step present (ensures the image builds cleanly before merge) |
+| Dependency update automation configured | `dependabot.yml` with relevant package ecosystems, OR Renovate config present |

--- a/skills/smaqit.project-diagnose/assets/checklists/logging.md
+++ b/skills/smaqit.project-diagnose/assets/checklists/logging.md
@@ -1,0 +1,16 @@
+# Logging Checklist
+
+10 checks for log configuration, persistence, and observability.
+
+| Check | Pass Condition |
+|-------|----------------|
+| Log handler is rotating (not plain file/stream) | Inventory `logging.handler_type` is `"rotating"`; plain file or stream handler is a fail |
+| Log files persisted via volume mount | Inventory `logging.volume_mount` is `true` — a log directory is mounted into the backend container |
+| `LOG_LEVEL` env var present in `.env.example` | `LOG_LEVEL` key present in the env example file |
+| Request correlation ID middleware present | Middleware injects a unique request ID per request that propagates into log records |
+| Container log driver configured for backend | Inventory `container.services_with_logging` includes the backend service |
+| Container log `max-size` limit set for backend | `max-size` option set under the backend service logging config |
+| Container log `max-file` limit set for backend | `max-file` option set under the backend service logging config |
+| Web server access log format is structured | Custom structured log format defined (not default `combined`); JSON or key=value preferred |
+| Web server error log level configured explicitly | Error log directive present with an explicit severity level |
+| Log formatter outputs structured fields | Formatter produces structured records including `timestamp`, `level`, `logger`, and `message` |

--- a/skills/smaqit.project-diagnose/assets/checklists/monitoring.md
+++ b/skills/smaqit.project-diagnose/assets/checklists/monitoring.md
@@ -1,0 +1,14 @@
+# Monitoring Checklist
+
+8 checks for runtime observability and failure detection.
+
+| Check | Pass Condition |
+|-------|----------------|
+| `/health` HTTP endpoint present | Route exists and returns 2xx with a basic status payload |
+| `/ready` HTTP endpoint present | Route exists and probes downstream dependencies (DB, data store) before returning 200 |
+| `/metrics` endpoint or instrumentation present | Metrics endpoint registered OR Prometheus/OpenMetrics middleware active |
+| Metrics instrumentation library in dependencies | Instrumentation library declared in the backend package manifest |
+| Container `healthcheck` present on backend service | Inventory `container.services_with_healthcheck` includes the backend service |
+| Container `healthcheck` present on frontend service | Inventory `container.services_with_healthcheck` includes the frontend service |
+| Container `healthcheck` present on web server service | Inventory `container.services_with_healthcheck` includes the web server service |
+| Alerting configuration exists | Alerting config file present (Alertmanager, Grafana, etc.), or deployment docs include an escalation procedure |

--- a/skills/smaqit.project-diagnose/assets/checklists/provisioning.md
+++ b/skills/smaqit.project-diagnose/assets/checklists/provisioning.md
@@ -1,0 +1,16 @@
+# Provisioning Checklist
+
+10 checks for infrastructure repeatability, backup coverage, and secrets management.
+
+| Check | Pass Condition |
+|-------|----------------|
+| IaC present (Ansible, Terraform, or equivalent) | At least one IaC file present that describes the deployment environment |
+| Systemd unit for autostart present | Inventory `provisioning.systemd_unit` is `true` — a `.service` unit file targets the compose stack or application |
+| Backup script deployment path matches actual deployment | The hardcoded path variable in the backup script matches the path documented in project materials |
+| Backup script covers database | Inventory `backup.covers_database` is `true` — a database dump utility is invoked |
+| Backup script covers `.env` / secrets | Inventory `backup.covers_config` is `true` — `.env` or equivalent config file is included |
+| Backup script covers application-specific config | Application-specific configuration (e.g. agent config export, settings dump) exported or backed up |
+| Backup script covers data volumes | Inventory `backup.covers_volumes` is `true` — data volumes or external service data directories included |
+| Backup rotation configured | Old backup directories pruned automatically (e.g. `find ... -mtime`, `rm` of aged backups) |
+| Secrets at rest are encrypted | Inventory `provisioning.secret_tool` is not `"none"` (e.g. SOPS, Ansible Vault, HashiCorp Vault) |
+| First-deploy / onboarding documentation exists | Onboarding or first-deploy documentation present and references current stack components |

--- a/skills/smaqit.project-diagnose/assets/checklists/security.md
+++ b/skills/smaqit.project-diagnose/assets/checklists/security.md
@@ -1,0 +1,20 @@
+# Security Checklist
+
+14 checks for security posture at system boundaries.
+
+| Check | Pass Condition |
+|-------|----------------|
+| Caller-supplied `role` in registration schema | `role` field absent from the inbound request schema, OR field is not caller-settable (hardcoded server-side, not accepted from request body) |
+| Role field has no exploitable default | If `role` field exists, default must be hardcoded to an unprivileged value (e.g. `"user"`); `null`/`None` or missing default is a fail |
+| `SECRET_KEY` / `AUTH_SECRET` has no hardcoded fallback | No hardcoded fallback string; key is required and raises an error if absent |
+| `COOKIE_SECURE` defaults to `True` | Default is `True`/`Secure`, or the env var is required with no fallback |
+| Cookie `HttpOnly` flag enabled | `httponly=True` (or `HttpOnly` header directive) present on auth cookies |
+| Cookie `SameSite` attribute set | `samesite="lax"` or `"strict"` (or `SameSite=Lax/Strict` header) present |
+| Rate limiting middleware present | Rate limiting middleware registered on the application |
+| Rate limiting applied to auth endpoints | At least the login route has a rate limit decorator or is covered by a global limiter |
+| CSRF protection or CORS restricted to known origins | `allow_origins` does not include `"*"` on a state-modifying API; or CSRF token middleware present |
+| Local login flag enforced in login route | Login route returns 403/disabled when the local login feature flag is disabled; flag is not silently ignored |
+| File upload validates MIME type | MIME type checked against an allowlist before processing |
+| File upload validates file size | Size limit enforced before processing |
+| File path operations use safe join | Paths constructed with safe join + realpath check, or UUID-based storage keys used (no raw user-supplied filenames in paths) |
+| Web server adds security response headers | At least `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy` headers present |

--- a/skills/smaqit.project-diagnose/assets/checklists/testing.md
+++ b/skills/smaqit.project-diagnose/assets/checklists/testing.md
@@ -1,0 +1,18 @@
+# Testing Checklist
+
+12 checks for test infrastructure completeness.
+
+| Check | Pass Condition |
+|-------|----------------|
+| Backend test files exist | Count > 0 |
+| Frontend test files exist | Count > 0 |
+| Backend test runner configured | Language-specific runner config present (e.g. `[tool.pytest]`, `jest.config.*`, Maven Surefire, `go test`) |
+| Backend test fixtures / setup file present | Fixture or setup file present for the detected language (e.g. `conftest.py`, `testify`, `spec_helper.rb`) |
+| Frontend test runner configured | Test runner config present (e.g. `vitest.config.*`, `jest.config.*`) |
+| Backend test coverage configured | Coverage reporting configured in package manifest or dedicated coverage config |
+| Backend coverage threshold set | Coverage threshold configured and non-zero |
+| Frontend test coverage configured | Coverage reporter configured in frontend package manifest or test runner config |
+| CI workflow runs backend tests | Backend test runner invoked in at least one non-smaqit workflow |
+| CI workflow runs frontend tests | Frontend test runner invoked in at least one non-smaqit workflow |
+| Tests do not import production `.env` | No direct `.env` file read in test files (e.g. `load_dotenv`, `open(".env")`, `dotenv.config()`) |
+| Test isolation: no shared mutable state across modules | No session-scoped fixtures that mutate global state without explicit teardown |

--- a/skills/smaqit.project-diagnose/scripts/diagnose-inventory.sh
+++ b/skills/smaqit.project-diagnose/scripts/diagnose-inventory.sh
@@ -1,0 +1,418 @@
+#!/usr/bin/env bash
+# diagnose-inventory.sh — stack-agnostic workspace inventory for smaqit.project-diagnose
+#
+# Run from workspace root:
+#   bash .github/skills/smaqit.project-diagnose/scripts/diagnose-inventory.sh
+#
+# The agent sets StackProfile fields as environment variables before calling this script.
+# All variables have auto-detection fallbacks so the script is always runnable stand-alone.
+#
+# Inputs (env vars — all optional):
+#   DIAG_BACKEND_DIR             e.g. "backend"
+#   DIAG_FRONTEND_DIR            e.g. "frontend"
+#   DIAG_BACKEND_LANG            python|node|go|java|ruby|dotnet|unknown
+#   DIAG_FRONTEND_LANG           typescript|javascript|unknown
+#   DIAG_TEST_BACKEND_PATTERNS   comma-separated globs, e.g. "test_*.py,*_test.py"
+#   DIAG_TEST_FRONTEND_PATTERNS  comma-separated globs, e.g. "*.test.ts,*.test.tsx"
+#   DIAG_VENDOR_EXCLUDES         comma-separated dirs to prune, e.g. ".venv,node_modules"
+#   DIAG_LOG_FILE                relative path to log module, e.g. "backend/logger.py"
+#   DIAG_COMPOSE_FILE            relative path to compose file, e.g. "docker-compose.yml"
+#   DIAG_BACKUP_SCRIPT           relative path to backup script, e.g. "scripts/backup.sh"
+#
+# Output: single JSON object to stdout
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Auto-detect StackProfile fields if not provided by the agent
+# ---------------------------------------------------------------------------
+
+# backend_dir
+DIAG_BACKEND_DIR="${DIAG_BACKEND_DIR:-}"
+if [ -z "$DIAG_BACKEND_DIR" ]; then
+  for d in backend src app server; do
+    if [ -d "$d" ]; then DIAG_BACKEND_DIR="$d"; break; fi
+  done
+  DIAG_BACKEND_DIR="${DIAG_BACKEND_DIR:-.}"
+fi
+
+# frontend_dir
+DIAG_FRONTEND_DIR="${DIAG_FRONTEND_DIR:-}"
+if [ -z "$DIAG_FRONTEND_DIR" ]; then
+  for d in frontend client web ui; do
+    if [ -d "$d" ] && [ -f "$d/package.json" ]; then DIAG_FRONTEND_DIR="$d"; break; fi
+  done
+fi
+
+# backend_lang
+DIAG_BACKEND_LANG="${DIAG_BACKEND_LANG:-}"
+if [ -z "$DIAG_BACKEND_LANG" ]; then
+  if [ -f "$DIAG_BACKEND_DIR/pyproject.toml" ] || [ -f "$DIAG_BACKEND_DIR/requirements.txt" ] || [ -f "pyproject.toml" ]; then
+    DIAG_BACKEND_LANG="python"
+  elif [ -f "go.mod" ] || [ -f "$DIAG_BACKEND_DIR/go.mod" ]; then
+    DIAG_BACKEND_LANG="go"
+  elif [ -f "pom.xml" ] || [ -f "build.gradle" ]; then
+    DIAG_BACKEND_LANG="java"
+  elif [ -f "Gemfile" ]; then
+    DIAG_BACKEND_LANG="ruby"
+  elif ls *.csproj 2>/dev/null | grep -q .; then
+    DIAG_BACKEND_LANG="dotnet"
+  elif [ -f "$DIAG_BACKEND_DIR/package.json" ] || [ -f "package.json" ]; then
+    DIAG_BACKEND_LANG="node"
+  else
+    DIAG_BACKEND_LANG="unknown"
+  fi
+fi
+
+# test patterns
+DIAG_TEST_BACKEND_PATTERNS="${DIAG_TEST_BACKEND_PATTERNS:-}"
+if [ -z "$DIAG_TEST_BACKEND_PATTERNS" ]; then
+  case "$DIAG_BACKEND_LANG" in
+    python)  DIAG_TEST_BACKEND_PATTERNS="test_*.py,*_test.py" ;;
+    go)      DIAG_TEST_BACKEND_PATTERNS="*_test.go" ;;
+    java)    DIAG_TEST_BACKEND_PATTERNS="*Test.java,*Spec.java,*IT.java" ;;
+    ruby)    DIAG_TEST_BACKEND_PATTERNS="*_spec.rb,*_test.rb" ;;
+    node)    DIAG_TEST_BACKEND_PATTERNS="*.test.js,*.spec.js,*.test.ts,*.spec.ts" ;;
+    dotnet)  DIAG_TEST_BACKEND_PATTERNS="*Tests.cs,*Spec.cs" ;;
+    *)       DIAG_TEST_BACKEND_PATTERNS="*test*,*spec*" ;;
+  esac
+fi
+DIAG_TEST_FRONTEND_PATTERNS="${DIAG_TEST_FRONTEND_PATTERNS:-*.test.ts,*.test.tsx,*.spec.ts,*.spec.tsx,*.test.js,*.spec.js}"
+
+# vendor excludes
+DIAG_VENDOR_EXCLUDES="${DIAG_VENDOR_EXCLUDES:-}"
+if [ -z "$DIAG_VENDOR_EXCLUDES" ]; then
+  case "$DIAG_BACKEND_LANG" in
+    python)  DIAG_VENDOR_EXCLUDES=".venv,__pycache__" ;;
+    node)    DIAG_VENDOR_EXCLUDES="node_modules" ;;
+    go)      DIAG_VENDOR_EXCLUDES="vendor" ;;
+    java)    DIAG_VENDOR_EXCLUDES="target,build" ;;
+    ruby)    DIAG_VENDOR_EXCLUDES="vendor/bundle" ;;
+    dotnet)  DIAG_VENDOR_EXCLUDES="bin,obj" ;;
+    *)       DIAG_VENDOR_EXCLUDES="vendor,node_modules" ;;
+  esac
+fi
+
+# log file
+DIAG_LOG_FILE="${DIAG_LOG_FILE:-}"
+if [ -z "$DIAG_LOG_FILE" ]; then
+  for candidate in \
+      "$DIAG_BACKEND_DIR/logger.py" "$DIAG_BACKEND_DIR/logging.py" "$DIAG_BACKEND_DIR/log.py" \
+      "$DIAG_BACKEND_DIR/logger.ts" "$DIAG_BACKEND_DIR/logger.js" \
+      "$DIAG_BACKEND_DIR/logger.go" "$DIAG_BACKEND_DIR/internal/logger/logger.go" \
+      "src/main/resources/logback.xml" "src/main/resources/log4j2.xml"; do
+    if [ -f "$candidate" ]; then DIAG_LOG_FILE="$candidate"; break; fi
+  done
+  DIAG_LOG_FILE="${DIAG_LOG_FILE:-unknown}"
+fi
+
+# compose file
+DIAG_COMPOSE_FILE="${DIAG_COMPOSE_FILE:-}"
+if [ -z "$DIAG_COMPOSE_FILE" ]; then
+  for candidate in docker-compose.yml docker-compose.yaml compose.yml compose.yaml; do
+    if [ -f "$candidate" ]; then DIAG_COMPOSE_FILE="$candidate"; break; fi
+  done
+  DIAG_COMPOSE_FILE="${DIAG_COMPOSE_FILE:-none}"
+fi
+
+# backup script
+DIAG_BACKUP_SCRIPT="${DIAG_BACKUP_SCRIPT:-}"
+if [ -z "$DIAG_BACKUP_SCRIPT" ]; then
+  for candidate in scripts/backup.sh backup.sh scripts/backup.py Makefile; do
+    if [ -f "$candidate" ]; then DIAG_BACKUP_SCRIPT="$candidate"; break; fi
+  done
+  DIAG_BACKUP_SCRIPT="${DIAG_BACKUP_SCRIPT:-none}"
+fi
+
+# ---------------------------------------------------------------------------
+# Helper: build find -not -path exclusion arguments from comma-separated list
+# ---------------------------------------------------------------------------
+build_exclude_args() {
+  local excludes="$1" args=""
+  IFS=',' read -ra parts <<< "$excludes"
+  for ex in "${parts[@]}"; do
+    ex="${ex#"${ex%%[![:space:]]*}"}"
+    args="$args -not -path '*/${ex}/*'"
+  done
+  echo "$args"
+}
+
+BACKEND_EXCLUDES=$(build_exclude_args "$DIAG_VENDOR_EXCLUDES")
+FRONTEND_EXCLUDES="-not -path '*/node_modules/*'"
+
+# ---------------------------------------------------------------------------
+# 1. Test file counts
+# ---------------------------------------------------------------------------
+count_test_files() {
+  local dir="$1" patterns="$2" excludes="$3"
+  [ ! -d "$dir" ] && echo 0 && return
+  local total=0
+  IFS=',' read -ra pats <<< "$patterns"
+  for pat in "${pats[@]}"; do
+    pat="${pat#"${pat%%[![:space:]]*}"}"
+    n=$(eval "find \"$dir\" $excludes -name \"$pat\" 2>/dev/null" | wc -l | tr -d ' ')
+    total=$((total + n))
+  done
+  echo "$total"
+}
+
+backend_tests=$(count_test_files "$DIAG_BACKEND_DIR" "$DIAG_TEST_BACKEND_PATTERNS" "$BACKEND_EXCLUDES")
+frontend_tests=0
+if [ -n "$DIAG_FRONTEND_DIR" ] && [ -d "$DIAG_FRONTEND_DIR" ]; then
+  frontend_tests=$(count_test_files "$DIAG_FRONTEND_DIR" "$DIAG_TEST_FRONTEND_PATTERNS" "$FRONTEND_EXCLUDES")
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Test runner / config presence (language-adaptive)
+# ---------------------------------------------------------------------------
+has_backend_runner_config=false
+has_backend_test_config=false
+has_frontend_runner_config=false
+
+case "$DIAG_BACKEND_LANG" in
+  python)
+    { [ -f "$DIAG_BACKEND_DIR/pytest.ini" ] || [ -f "pytest.ini" ] || \
+      ([ -f "$DIAG_BACKEND_DIR/pyproject.toml" ] && grep -q 'tool.pytest' "$DIAG_BACKEND_DIR/pyproject.toml" 2>/dev/null); } \
+      && has_backend_runner_config=true || true
+    { [ -f "$DIAG_BACKEND_DIR/conftest.py" ] || [ -f "conftest.py" ]; } \
+      && has_backend_test_config=true || true
+    ;;
+  go)
+    grep -rq 'testify\|testing.T' "$DIAG_BACKEND_DIR" 2>/dev/null \
+      && has_backend_runner_config=true || true
+    has_backend_test_config=true
+    ;;
+  java)
+    { [ -f "pom.xml" ] && grep -q 'maven-surefire\|junit\|testng' pom.xml 2>/dev/null; } \
+      && has_backend_runner_config=true || true
+    ;;
+  node|dotnet|ruby)
+    { ls "$DIAG_BACKEND_DIR"/jest.config.* 2>/dev/null | grep -q . || \
+      ls "$DIAG_BACKEND_DIR"/vitest.config.* 2>/dev/null | grep -q .; } \
+      && has_backend_runner_config=true || true
+    ;;
+esac
+
+if [ -n "$DIAG_FRONTEND_DIR" ] && [ -d "$DIAG_FRONTEND_DIR" ]; then
+  { ls "$DIAG_FRONTEND_DIR"/vitest.config.* 2>/dev/null | grep -q . || \
+    ls "$DIAG_FRONTEND_DIR"/jest.config.* 2>/dev/null | grep -q . || \
+    ls vitest.config.* 2>/dev/null | grep -q .; } \
+    && has_frontend_runner_config=true || true
+fi
+
+# ---------------------------------------------------------------------------
+# 3. CI workflows: list non-smaqit workflow files
+# ---------------------------------------------------------------------------
+ci_files=()
+ci_dir_detected="none"
+
+if [ -d ".github/workflows" ]; then
+  ci_dir_detected=".github/workflows"
+  for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+    [ -f "$f" ] || continue
+    fname=$(basename "$f")
+    echo "$fname" | grep -qi 'smaqit' && continue || true
+    head -10 "$f" 2>/dev/null | grep -qi 'smaqit' && continue || true
+    ci_files+=("$fname")
+  done
+elif [ -f ".gitlab-ci.yml" ]; then
+  ci_dir_detected=".gitlab-ci.yml"
+  ci_files+=(".gitlab-ci.yml")
+elif [ -f "Jenkinsfile" ]; then
+  ci_dir_detected="Jenkinsfile"
+  ci_files+=("Jenkinsfile")
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Log handler type (language-adaptive)
+# ---------------------------------------------------------------------------
+log_handler="unknown"
+if [ -f "$DIAG_LOG_FILE" ]; then
+  case "$DIAG_BACKEND_LANG" in
+    python)
+      if grep -q 'RotatingFileHandler\|TimedRotatingFileHandler' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="rotating"
+      elif grep -q 'FileHandler' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="file"
+      elif grep -q 'StreamHandler\|console' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="stream"
+      fi ;;
+    node)
+      if grep -qi 'DailyRotateFile\|rotating\|winston-daily' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="rotating"
+      elif grep -qi 'transports.File\|createWriteStream' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="file"
+      else
+        log_handler="stream"
+      fi ;;
+    go)
+      if grep -qi 'lumberjack\|rotating\|rollingfile' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="rotating"
+      elif grep -qi 'os.Create\|os.OpenFile' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="file"
+      else
+        log_handler="stream"
+      fi ;;
+    java)
+      if grep -qi 'RollingFileAppender\|SizeAndTimeBasedRollingPolicy' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="rotating"
+      elif grep -qi 'FileAppender' "$DIAG_LOG_FILE" 2>/dev/null; then
+        log_handler="file"
+      fi ;;
+    *)
+      grep -qi 'rotat' "$DIAG_LOG_FILE" 2>/dev/null && log_handler="rotating" || \
+        grep -qi 'file' "$DIAG_LOG_FILE" 2>/dev/null && log_handler="file" || true
+      ;;
+  esac
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Log volume mount
+# ---------------------------------------------------------------------------
+log_volume=false
+if [ "$DIAG_COMPOSE_FILE" != "none" ] && [ -f "$DIAG_COMPOSE_FILE" ]; then
+  grep -E '\./logs|/var/log/app' "$DIAG_COMPOSE_FILE" 2>/dev/null | grep -q . && log_volume=true || true
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Container services: logging config and healthchecks (generic, via python3)
+# ---------------------------------------------------------------------------
+all_services=""
+logging_svcs=""
+hc_svcs=""
+
+if [ "$DIAG_COMPOSE_FILE" != "none" ] && [ -f "$DIAG_COMPOSE_FILE" ]; then
+  _svc_data=$(python3 - "$DIAG_COMPOSE_FILE" << 'PYEOF'
+import re, sys, json
+content = open(sys.argv[1]).read()
+lines = content.split("\n")
+cur = None
+has_logging, has_hc, services = set(), set(), set()
+for line in lines:
+    m = re.match(r"^  (\w[\w-]*):", line)
+    if m:
+        cur = m.group(1)
+        services.add(cur)
+    if cur:
+        if re.match(r"\s{4,}logging:", line): has_logging.add(cur)
+        if re.match(r"\s{4,}healthcheck:", line): has_hc.add(cur)
+print(json.dumps({"services": sorted(services), "logging": sorted(has_logging), "healthcheck": sorted(has_hc)}))
+PYEOF
+  )
+  all_services=$(echo "$_svc_data" | python3 -c "import sys,json; d=json.load(sys.stdin); print(','.join(d['services']))" 2>/dev/null || true)
+  logging_svcs=$(echo "$_svc_data" | python3 -c "import sys,json; d=json.load(sys.stdin); print(','.join(d['logging']))" 2>/dev/null || true)
+  hc_svcs=$(echo "$_svc_data" | python3 -c "import sys,json; d=json.load(sys.stdin); print(','.join(d['healthcheck']))" 2>/dev/null || true)
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Backup script — generic coverage checks
+# ---------------------------------------------------------------------------
+backup_hardcoded_path="not found"
+backup_has_db=false
+backup_has_config=false
+backup_has_volumes=false
+
+if [ "$DIAG_BACKUP_SCRIPT" != "none" ] && [ -f "$DIAG_BACKUP_SCRIPT" ]; then
+  # Hardcoded deployment path variable
+  _raw=$(grep -E '^(APP_DIR|BACKUP_DIR|BASE_DIR|DEPLOY_DIR|PROJECT_DIR)=' "$DIAG_BACKUP_SCRIPT" 2>/dev/null | head -1 || true)
+  if [ -n "$_raw" ]; then
+    backup_hardcoded_path=$(echo "$_raw" | sed 's/^[^=]*=//' | tr -d '"' | tr -d "'")
+  fi
+  # Database backup utility
+  grep -qiE 'pg_dump|pg_dumpall|mysqldump|mongodump|sqlite3.*backup|db.backup|database.backup' \
+    "$DIAG_BACKUP_SCRIPT" 2>/dev/null && backup_has_db=true || true
+  # Config/secrets backup
+  grep -qiE '\.env|config\.yml|config\.json|secrets' \
+    "$DIAG_BACKUP_SCRIPT" 2>/dev/null && backup_has_config=true || true
+  # Volume/data directory backup
+  grep -qiE 'volumes?/|data/|tar |rsync|cp -r' \
+    "$DIAG_BACKUP_SCRIPT" 2>/dev/null && backup_has_volumes=true || true
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Systemd unit
+# ---------------------------------------------------------------------------
+systemd_unit=false
+find . -maxdepth 4 -name '*.service' 2>/dev/null | grep -q . && systemd_unit=true || true
+
+# ---------------------------------------------------------------------------
+# 9. Secrets tool
+# ---------------------------------------------------------------------------
+secret_tool="none"
+if [ -f ".sops.yaml" ] || [ -f ".sops.yml" ]; then
+  secret_tool="sops"
+elif grep -qr 'ansible-vault' deploy/ scripts/ 2>/dev/null; then
+  secret_tool="ansible-vault"
+elif [ -f ".vault-token" ] || grep -qr '"vault"' deploy/ 2>/dev/null; then
+  secret_tool="vault"
+fi
+
+# ---------------------------------------------------------------------------
+# 10. .env.example keys (field names only, no values)
+# ---------------------------------------------------------------------------
+env_keys=()
+for envfile in .env.example .env.sample .env.template; do
+  if [ -f "$envfile" ]; then
+    while IFS= read -r line; do
+      [[ "$line" =~ ^[[:space:]]*# ]] && continue || true
+      [[ "$line" =~ ^[[:space:]]*$ ]] && continue || true
+      key=$(echo "$line" | cut -d'=' -f1 | tr -d ' ')
+      [ -n "$key" ] && env_keys+=("$key") || true
+    done < "$envfile"
+    break
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Serialize and output JSON
+# ---------------------------------------------------------------------------
+ci_count="${#ci_files[@]}"
+ci_json=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1:]))" "${ci_files[@]+"${ci_files[@]}"}" 2>/dev/null || echo "[]")
+keys_json=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1:]))" "${env_keys[@]+"${env_keys[@]}"}" 2>/dev/null || echo "[]")
+
+# Convert bash true/false to Python True/False
+_py() { [ "$1" = "true" ] && echo "True" || echo "False"; }
+_py_backend_runner=$(_py "$has_backend_runner_config")
+_py_backend_test=$(_py "$has_backend_test_config")
+_py_frontend_runner=$(_py "$has_frontend_runner_config")
+_py_log_volume=$(_py "$log_volume")
+_py_backup_db=$(_py "$backup_has_db")
+_py_backup_config=$(_py "$backup_has_config")
+_py_backup_volumes=$(_py "$backup_has_volumes")
+_py_systemd=$(_py "$systemd_unit")
+
+python3 - << PYEOF
+import json
+print(json.dumps({
+    "stack_profile": {
+        "backend_dir": "${DIAG_BACKEND_DIR}",
+        "frontend_dir": "${DIAG_FRONTEND_DIR:-}",
+        "backend_lang": "${DIAG_BACKEND_LANG}",
+        "log_file": "${DIAG_LOG_FILE}",
+        "compose_file": "${DIAG_COMPOSE_FILE}",
+        "backup_script": "${DIAG_BACKUP_SCRIPT}"
+    },
+    "test_files": {"backend": ${backend_tests}, "frontend": ${frontend_tests}},
+    "test_configs": {
+        "backend_runner_config": ${_py_backend_runner},
+        "backend_test_fixtures": ${_py_backend_test},
+        "frontend_runner_config": ${_py_frontend_runner}
+    },
+    "ci_workflows": {"count": ${ci_count}, "ci_dir": "${ci_dir_detected}", "files": ${ci_json}},
+    "logging": {"handler_type": "${log_handler}", "volume_mount": ${_py_log_volume}},
+    "container": {
+        "compose_file": "${DIAG_COMPOSE_FILE}",
+        "all_services": "${all_services:-}",
+        "services_with_logging": "${logging_svcs:-}",
+        "services_with_healthcheck": "${hc_svcs:-}"
+    },
+    "backup": {
+        "script": "${DIAG_BACKUP_SCRIPT}",
+        "hardcoded_path": "${backup_hardcoded_path}",
+        "covers_database": ${_py_backup_db},
+        "covers_config": ${_py_backup_config},
+        "covers_volumes": ${_py_backup_volumes}
+    },
+    "provisioning": {"systemd_unit": ${_py_systemd}, "secret_tool": "${secret_tool}"},
+    "env_example_keys": ${keys_json}
+}, indent=2))
+PYEOF


### PR DESCRIPTION
## Release v1.4.0 — smaqit.project-diagnose

### Added
- **smaqit.project-diagnose** skill v1.1.0 — scans project structure for gaps across testing, security, logging, monitoring, provisioning, and CI/CD domains. Produces prioritised finding reports with 6 domain checklists and optional task creation.

### Changed
- **Makefile** — added project-diagnose to sync list; assets copy changed to recursive (`cp -rfL`) for nested asset directories
- Release version metadata updated to 1.4.0