### PR TITLE
Prepare release v1.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.2] - 2026-08-15
+
 ### Fixed
-- **Session-finish push confirmation gate relaxed** (pending v1.17.2 · PR #125) — `smaqit.session-finish`'s Step 7 no longer stops for explicit confirmation before the routine commit and push of main's own known files; every hard-stop condition (detached HEAD, conflicts, unexpected rejection, diverged history, auth failure, foreign changes) still stops unconditionally exactly as before. Since this left no remaining functional difference between the skill's Assisted and Autonomous modes, the `--autonomous` flag and all mode language are removed entirely rather than kept as a documented no-op — `## Usage` now documents a single invocation.
+- **Session-finish push confirmation gate relaxed** — `smaqit.session-finish`'s Step 7 no longer stops for explicit confirmation before the routine commit and push of main's own known files; every hard-stop condition (detached HEAD, conflicts, unexpected rejection, diverged history, auth failure, foreign changes) still stops unconditionally exactly as before. Since this left no remaining functional difference between the skill's Assisted and Autonomous modes, the `--autonomous` flag and all mode language are removed entirely rather than kept as a documented no-op — `## Usage` now documents a single invocation.
 
 ## [1.17.1] - 2026-08-14
 

--- a/skills/smaqit.session-finish/SKILL.md
+++ b/skills/smaqit.session-finish/SKILL.md
@@ -2,7 +2,7 @@
 name: smaqit.session-finish
 description: End session by documenting the entire conversation. Use at session completion to create history entries.
 metadata:
-  version: "0.10.0"
+  version: "0.10.1"
 ---
 
 # Session Finish
@@ -12,8 +12,7 @@ End a session by documenting the **entire session** (not just recent activity).
 ## Usage
 
 ```
-session.finish                     # Assisted mode (default) - stops for confirmation before commit/push
-session.finish --autonomous        # Autonomous mode - commits/pushes automatically when safe
+session.finish                     # Documents the session, then finalizes main's git state; stops only on the failure-handling conditions below
 ```
 
 ## Steps
@@ -94,11 +93,11 @@ session.finish --autonomous        # Autonomous mode - commits/pushes automatica
    - Check the current branch and status (`git branch --show-current`, `git status --porcelain`). If already on `main`, clean, and in sync with `origin/main`, there is nothing to do.
    - If the situation is straightforward, resolve it directly:
      - On a different branch with a clean tree → `git checkout main`.
-     - Uncommitted changes on `main` from files this run itself wrote (the Step 2 history file; `.smaqit/compendium.md` if Step 6 updated it; `.smaqit/references/project-research.md` if Step 4 refreshed it) → stage exactly those paths (never `git add -A` or a broader path) and commit. **Assisted:** list the files and stop for explicit confirmation before committing. **Autonomous:** commit directly.
+     - Uncommitted changes on `main` from files this run itself wrote (the Step 2 history file; `.smaqit/compendium.md` if Step 6 updated it; `.smaqit/references/project-research.md` if Step 4 refreshed it) → stage exactly those paths (never `git add -A` or a broader path) and commit.
      - Behind `origin/main` with no local commits of your own → `git fetch origin main && git pull --ff-only origin main`.
-     - Ahead of `origin/main` with nothing to pull → push. **Assisted:** report the commits ready to push and stop for explicit confirmation. **Autonomous:** `git push origin main` directly.
-   - **If anything doesn't resolve cleanly on the first safe attempt, or the situation is ambiguous or risky** — a detached HEAD, an in-progress merge/conflict, a dirty branch other than `main`, diverged history, an unexpected push rejection, an authentication failure, or anything else you're not confident is safe — **STOP.** Report exactly what you observed and take no further action, in both Assisted and Autonomous mode. Do not guess, retry, or improvise a fix.
-   - **Never attempt, in either mode:** resolving a merge conflict, force-pushing, hard-resetting or discarding uncommitted work, rebasing, fixing an authentication/permission failure, or touching a branch or worktree other than the primary checkout's `main`. Report any of these situations to the user; do not solve them.
+     - Ahead of `origin/main` with nothing to pull → `git push origin main`.
+   - **If anything doesn't resolve cleanly on the first safe attempt, or the situation is ambiguous or risky** — a detached HEAD, an in-progress merge/conflict, a dirty branch other than `main`, diverged history, an unexpected push rejection, an authentication failure, or anything else you're not confident is safe — **STOP.** Report exactly what you observed and take no further action. Do not guess, retry, or improvise a fix.
+   - **Never attempt:** resolving a merge conflict, force-pushing, hard-resetting or discarding uncommitted work, rebasing, fixing an authentication/permission failure, or touching a branch or worktree other than the primary checkout's `main`. Report any of these situations to the user; do not solve them.
 
 ## Requirements
 


### PR DESCRIPTION
## Task 029 — Relax Session-Finish Push Confirmation Gate

Removes the Assisted/Autonomous confirmation-branching sentences from `smaqit.session-finish`'s Step 7 commit and push bullets, so the routine case (known, self-authored files; clean fast-forward push) proceeds without stopping to ask. Every existing hard-stop condition (detached HEAD, conflicts, unexpected rejection, diverged history, auth failure, foreign changes) is unchanged and still stops unconditionally.

Scope widened during review: since Step 7 no longer branches on mode, Assisted vs Autonomous had zero remaining functional difference in this skill, so the mode concept is dropped entirely rather than kept as a documented no-op — `## Usage` collapses to a single invocation with no `--autonomous` flag, and the two failure-handling STOP bullets drop their now-vestigial "in both/either mode" phrasing while keeping every condition and action unchanged in substance. Confirmed no other skill or script in the repo depends on the flag before removing it. `task-start`/`task-complete`'s own per-task `Mode` field is a separate mechanism and is unaffected.

`smaqit.session-finish` bumped 0.10.0 → 0.10.1.

### Post-Merge Automation

Merging this PR triggers `post-merge-release.yml`: tags `v1.17.2` and publishes the GitHub Release using the CHANGELOG entry promoted on this branch.