### PR TITLE
Prepare release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-08-16
+
 ### Fixed
-- **`update` no longer writes project-scoped agent/skill mirrors** (pending v2.0.1 · PR #128) — its post-self-update reinit now shares `init`'s scope-only scaffold path, so it never writes `.agents/`, `.claude/`, `.codex/`, `.github/agents/`, or `.github/skills/` into a project that never opted into `install --scope project`.
+- **`update` no longer writes project-scoped agent/skill mirrors** — its post-self-update reinit now shares `init`'s scope-only scaffold path, so it never writes `.agents/`, `.claude/`, `.codex/`, `.github/agents/`, or `.github/skills/` into a project that never opted into `install --scope project`.
 
 ## [2.0.0] - 2026-08-15
 

--- a/installer/main.go
+++ b/installer/main.go
@@ -1237,7 +1237,9 @@ func copyFile(src, dst string) error {
 }
 
 // checkAndReInit refreshes the global installation and, if the current
-// directory contains a .smaqit/ directory, re-scaffolds project templates.
+// directory contains a .smaqit/ directory, re-scaffolds project tracking.
+// Project re-scaffolding goes through scaffoldProject — the same path `init`
+// uses — and never installs project-scoped agent/skill mirrors.
 func checkAndReInit(dir string) {
 	// Always refresh the global install.
 	fmt.Println("Refreshing global installation...")
@@ -1245,16 +1247,19 @@ func checkAndReInit(dir string) {
 
 	smaqitPath := filepath.Join(dir, ".smaqit")
 	if _, err := os.Stat(smaqitPath); err != nil {
-		fmt.Println("Run `smaqit-extensions install --scope project` to scaffold project tracking")
+		fmt.Println("Run `smaqit-extensions init` to scaffold project tracking")
 		return
 	}
 
 	fmt.Println("Detected .smaqit/ — re-scaffolding project tracking...")
-	scaffoldSmaqit(dir)
+	scaffoldProject(dir)
 	fmt.Println("Re-scaffolded .smaqit/ project tracking")
 }
 
 // checkAndReInitWithBinary re-initializes in a fresh process after self-update.
+// The fresh binary runs `init`, which scaffolds project tracking only —
+// project-scoped agent/skill mirrors require an explicit
+// `install --scope project` and are never written by `update`.
 func checkAndReInitWithBinary(dir, binaryPath string) error {
 	// Always refresh the global install with the new binary.
 	cmd := exec.Command(binaryPath, "install")
@@ -1267,17 +1272,17 @@ func checkAndReInitWithBinary(dir, binaryPath string) error {
 
 	smaqitPath := filepath.Join(dir, ".smaqit")
 	if _, err := os.Stat(smaqitPath); err != nil {
-		fmt.Println("Run `smaqit-extensions install --scope project` to scaffold project tracking")
+		fmt.Println("Run `smaqit-extensions init` to scaffold project tracking")
 		return nil
 	}
 
 	fmt.Println("Detected .smaqit/ — re-scaffolding project tracking with updated binary...")
-	cmd2 := exec.Command(binaryPath, "install", "--scope", "project", dir)
+	cmd2 := exec.Command(binaryPath, "init", dir)
 	cmd2.Stdin = os.Stdin
 	cmd2.Stdout = os.Stdout
 	cmd2.Stderr = os.Stderr
 	if err := cmd2.Run(); err != nil {
-		return fmt.Errorf("running %s install --scope project: %w", binaryPath, err)
+		return fmt.Errorf("running %s init: %w", binaryPath, err)
 	}
 	return nil
 }

--- a/installer/main_test.go
+++ b/installer/main_test.go
@@ -45,9 +45,45 @@ func TestCheckAndReInitWithBinaryRunsFreshProcess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fresh process did not write marker: %v", err)
 	}
-	wantArgs := "args=install --scope project " + projectDir
+	wantArgs := "args=init " + projectDir
 	if !strings.Contains(string(payload), wantArgs) {
 		t.Fatalf("fresh process received wrong arguments: got %q, want payload containing %q", payload, wantArgs)
+	}
+	// Regression (task 033): update's reinit must never request a
+	// project-scoped agent/skill install.
+	if strings.Contains(string(payload), "--scope project") {
+		t.Fatalf("fresh process was asked for a project-scoped install: %q", payload)
+	}
+}
+
+// Regression (task 033): the scaffold path shared by `init` and `update`'s
+// reinit must create project tracking only — never the project-scoped
+// agent/skill mirror trees that `install --scope project` opts into.
+func TestScaffoldProjectCreatesOnlyProjectTrackingPaths(t *testing.T) {
+	projectDir := t.TempDir()
+	scaffoldProject(projectDir)
+
+	for _, want := range []string{
+		filepath.Join(".smaqit", "tasks"),
+		filepath.Join(".smaqit", "history"),
+		filepath.Join(".smaqit", "user-testing"),
+		filepath.Join(".github", "workflows"),
+	} {
+		if _, err := os.Stat(filepath.Join(projectDir, want)); err != nil {
+			t.Errorf("expected scaffolded path %s: %v", want, err)
+		}
+	}
+
+	for _, forbidden := range []string{
+		".agents",
+		".claude",
+		filepath.Join(".codex"),
+		filepath.Join(".github", "agents"),
+		filepath.Join(".github", "skills"),
+	} {
+		if _, err := os.Stat(filepath.Join(projectDir, forbidden)); err == nil {
+			t.Errorf("scaffolding created project-scoped mirror path %s", forbidden)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes task 033: `smaqit-extensions update` was silently writing a full project-scoped agent/skill mirror (231 files across `.agents/`, `.claude/`, `.codex/`, `.github/agents/`, `.github/skills/`) into any project directory it ran in, even projects deliberately migrated to global-only installation (task 023).

Root cause: `update`'s post-self-update reinit path (`checkAndReInitWithBinary`) re-execed the fresh binary with `install --scope project <dir>` — the internal/testing full-mirror install — instead of the scope-aware `init` path. This predated task 023's global-install migration and was never updated to match it.

Fix: both of `update`'s reinit routes (`checkAndReInitWithBinary`, post-download; `checkAndReInit`, same-version path) now converge on `scaffoldProject`, the exact function `init` uses, so `update` never writes project-scoped mirrors unless the project explicitly opts in via `install --scope project`.

## Test plan

- [x] `installer/main_test.go`: fixed `TestCheckAndReInitWithBinaryRunsFreshProcess` (previously asserted the buggy `install --scope project` invocation as expected behavior — this is why the defect went untested)
- [x] Added `TestScaffoldProjectCreatesOnlyProjectTrackingPaths` — asserts the shared scaffold path creates only `.smaqit/{tasks,history,user-testing}` and `.github/workflows`, never `.agents/`, `.claude/`, `.codex/`, `.github/agents/`, or `.github/skills/`
- [x] Verified the added regression test fails against the pre-fix code with the exact reported buggy invocation
- [x] `make test` (repo root, all six hermetic suites) passes
- [x] `make smoke-test` (full installer end-to-end) passes
- [x] Manual scratch-repo verification: `init` with the fixed binary produces exactly the four documented paths, all five mirror paths absent

## Post-Merge Automation

This PR's merge triggers `.github/workflows/post-merge-release.yml`'s tag + GitHub Release automation for v2.0.1 (PATCH — bug fix only, no new feature, no breaking change).