### PR TITLE
Prepare release v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **`update` no longer writes project-scoped agent/skill mirrors** (pending v2.0.1 · PR #128) — its post-self-update reinit now shares `init`'s scope-only scaffold path, so it never writes `.agents/`, `.claude/`, `.codex/`, `.github/agents/`, or `.github/skills/` into a project that never opted into `install --scope project`.
-- **Release boundary is detected from git tags instead of release-marker commits** (pending v2.0.2 · PR #129) — under the PR-gated per-task release model, `Prepare release vX.Y.Z` exists only as a PR title, so the marker regex never matched the merge commit GitHub actually writes and the boundary silently skipped back to the last pre-PR-gated release. `release-analysis` and `release-prepare-files` now resolve the boundary via `git describe --tags` against `origin/main`, keep the marker regex as a tagless fallback, and derive the version baseline from the highest reachable tag as a separate lookup so out-of-order per-task tags cannot regress a suggestion below an already-released version.
+
+## [2.0.2] - 2026-08-16
+
+### Fixed
+- **Release boundary is detected from git tags instead of release-marker commits** — under the PR-gated per-task release model, `Prepare release vX.Y.Z` exists only as a PR title, so the marker regex never matched the merge commit GitHub actually writes and the boundary silently skipped back to the last pre-PR-gated release. On this repository it had been resolving to `v1.17.1`, three releases stale. `release-analysis` and `release-prepare-files` now resolve the boundary via `git describe --tags` against `origin/main`, dereference it with `git rev-list -n1`, and keep the marker regex as a fallback for tagless repositories. The version baseline is now a separate lookup (`git tag --merged origin/main --sort=-v:refname`), so out-of-order per-task tags — which the per-task release model produces by design — cannot regress a suggestion below an already-released version. `release-prepare-files` Step 2A-2 is also realigned from local `HEAD` to `origin/main`.
 
 ## [2.0.0] - 2026-08-15
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: sync clean test smoke-test test-worktree-layout test-parent-task-lifecycle test-project-research-verify-urls test-triage-issues test-task-complete-pr-lifecycle test-release-analysis-pending-versions
+.PHONY: sync clean test smoke-test test-worktree-layout test-parent-task-lifecycle test-project-research-verify-urls test-triage-issues test-task-complete-pr-lifecycle test-release-analysis-pending-versions test-release-analysis-boundary-detection
 
 SKILLS := smaqit.session-start smaqit.project-diagnose smaqit.session-finish smaqit.session-assess smaqit.session-title smaqit.session-recap smaqit.task-create smaqit.task-list smaqit.task-complete smaqit.task-plan smaqit.task-refresh smaqit.task-start smaqit.test-create smaqit.test-complete smaqit.test-start smaqit.project-init smaqit.project-glossary smaqit.release-analysis smaqit.release-approval smaqit.release-prepare-files smaqit.release-git-local smaqit.release-git-pr smaqit.utils.read-pdf smaqit.utils.triage-issues smaqit.utils.worktree smaqit.project-research smaqit.project-recap smaqit.project-compendium smaqit.parity-assess
 
@@ -35,7 +35,10 @@ test-task-complete-pr-lifecycle:
 test-release-analysis-pending-versions:
 	@bash tests/skills/test-release-analysis-pending-versions.sh
 
-test: test-worktree-layout test-parent-task-lifecycle test-project-research-verify-urls test-triage-issues test-task-complete-pr-lifecycle test-release-analysis-pending-versions
+test-release-analysis-boundary-detection:
+	@bash tests/skills/test-release-analysis-boundary-detection.sh
+
+test: test-worktree-layout test-parent-task-lifecycle test-project-research-verify-urls test-triage-issues test-task-complete-pr-lifecycle test-release-analysis-pending-versions test-release-analysis-boundary-detection
 
 smoke-test: test
 	@$(MAKE) -C installer smoke-test

--- a/skills/smaqit.release-analysis/SKILL.md
+++ b/skills/smaqit.release-analysis/SKILL.md
@@ -2,7 +2,7 @@
 name: smaqit.release-analysis
 description: Collect changes, assess severity, and suggest next version for a release
 metadata:
-  version: "0.8.0"
+  version: "0.9.0"
 ---
 
 # Release Analysis
@@ -23,55 +23,75 @@ Use this skill at the start of a release workflow to:
 
 ### Step 1: Find the Release Boundary Commit
 
-The release workflows create exact release-marker commits in two compatible forms: `"Release vX.Y.Z"` for local releases and `"Prepare release vX.Y.Z"` for PR-based releases. Use the most recent marker of either form as the **authoritative lower boundary** for the current release delta. It is more reliable than git tags (absent in shallow clones) and more precise than PR merge timestamps (which can be incorrectly ordered).
+**Every release is tagged `vX.Y.Z`**, whichever flow produced it: `release-git-local` tags directly, and `post-merge-release.yml` tags on a merged release PR. Tags are therefore the **authoritative lower boundary** for the current release delta, and the only marker that survives both release eras.
 
-**Step 1a — Fetch and deepen so all history is visible and current:**
+Release-marker *commits* are not. They exist in two forms — `"Release vX.Y.Z"` (local) and `"Prepare release vX.Y.Z"` (PR-based) — but since the PR-gated per-task release model shipped, that exact string only ever appears as a **PR title**. The merge commit GitHub actually writes reads `Merge pull request #NNN from owner/branch`, which no marker pattern matches. A repository that has released through both eras therefore has a marker-commit history that silently stops at its last pre-PR-gated release. The regex is retained below only as a fallback for a repository with no tags at all.
+
+**Step 1a — Fetch and deepen so all history and tags are visible and current:**
 
 ```bash
 git fetch origin main 2>/dev/null || true
+git fetch --tags --force --quiet 2>/dev/null || true
 git fetch --unshallow 2>/dev/null || git fetch --depth=2147483647 2>/dev/null || true
 ```
 
+Fetching tags is **not optional** — it is what makes the tag-based boundary reliable in the shallow clones that originally motivated preferring commits over tags. `--force` prevents a moved tag leaving a stale local ref.
+
 The explicit `git fetch origin main` is not optional, in either mode: without it, the boundary search below walks whatever `origin/main` your local refs happened to have cached, which can be stale by the time of a second, concurrent invocation — the exact bug that would otherwise let two sibling tasks compute the same "next" version. Always fetch immediately before searching, never rely on a fetch performed earlier in the session.
 
-**Step 1b — Check whether HEAD itself is a release-marker commit** (Batch mode only; Task mode's `<task-branch>` is never itself a release-marker commit, skip this check):
+**Step 1b — Check whether the analysis tip is itself the latest release** (Batch mode only; Task mode's `<task-branch>` is never itself a released commit, skip this check):
 
 ```bash
-git log -1 --format="%s"
+git describe --tags --exact-match origin/main 2>/dev/null
 ```
+
+A match means `origin/main`'s tip *is* the most recent release, so that tag must not also serve as the delta's lower bound — Step 1c steps back one tag.
 
 **Step 1c — Find the boundary SHA:**
 
-Search **`origin/main`'s history**, not local `HEAD` or the task branch — this is the fix for the staleness bug above, and applies identically in both modes:
+Resolve against **`origin/main`**, not local `HEAD` or the task branch — this is the fix for the staleness bug above, and applies identically in both modes:
 
 ```bash
-# List every exact local or PR release marker in reverse-chronological order, from the fetched remote tip
-git log origin/main --format="%H %s" | grep -iE "^[0-9a-f]+ (Prepare release|Release) v[0-9]+\.[0-9]+\.[0-9]+$"
+# Most recent release tag reachable from the fetched remote tip
+git describe --tags --abbrev=0 origin/main
 ```
 
-- **Batch mode, HEAD is a release-marker commit** — take the **second** entry from the list above (the one immediately before the current release).
-- **Otherwise (Batch mode without a marker at HEAD, or Task mode)** — take the **first** entry.
+- **Batch mode, the tip is itself tagged** (Step 1b matched) — take the **next-older** tag instead:
+  ```bash
+  git describe --tags --abbrev=0 "$(git describe --tags --abbrev=0 origin/main)^"
+  ```
+- **Otherwise (Batch mode with an untagged tip, or Task mode)** — use the tag from the command above.
 
-Store the result as `<boundary-sha>`.
+Dereference the chosen tag to its commit and store that as `<boundary-sha>`:
+```bash
+git rev-list -n1 "<tag>"
+```
+`git rev-list -n1` resolves annotated and lightweight tags identically, so both tagging styles work unchanged.
 
 Confirm it with:
 ```bash
 git log -1 --oneline "<boundary-sha>"
 ```
 
-**Step 1d — Extract the last-released version** from the boundary commit message:
+**Step 1d — Determine the last-released version.**
+
+This is a **separate lookup from Step 1c**, not a re-read of the boundary commit — the two answer different questions and can legitimately disagree:
+
 ```bash
-git log -1 --format="%s" "<boundary-sha>" | grep -oE "v[0-9]+\.[0-9]+\.[0-9]+"
+git tag --merged origin/main --sort=-v:refname | head -1
 ```
 
 Store as `<last-version>` (e.g., `v1.1.2`).
 
-**Fallback (no release-marker commits exist — new repository):**
+Step 1c asks *"where does this release's delta begin?"* — answered by the **topologically latest** reachable tag. Step 1d asks *"what version must the next one exceed?"* — answered by the **highest-numbered** reachable tag. Under the per-task release model, each task's PR claims its version before merging and PRs merge in review order, not version order, so tags land out of numeric sequence by design. If PR #200 claims v2.1.0 and merges first, then PR #201 claims v2.0.1 and merges second, the topologically latest tag is `v2.0.1` while the highest is `v2.1.0`. Deriving the version baseline from the boundary commit would then suggest `v2.0.2` — **below the already-released v2.1.0**. Step 1e's pending-claim check does not catch this: by then the colliding version is released and promoted, no longer a pending annotation.
+
+**Fallback 1 (no tags — a repository that has only ever released via marker commits):**
 ```bash
-git fetch --tags --quiet 2>/dev/null || true
-git tag --sort=-v:refname | head -1
+git log origin/main --format="%H %s" | grep -iE "^[0-9a-f]+ (Prepare release|Release) v[0-9]+\.[0-9]+\.[0-9]+$"
 ```
-If tags are also empty, use `v0.0.0` as baseline and suggest `v0.1.0`.
+Take the second entry when Batch mode's tip is itself a marker commit, the first otherwise; use its SHA as `<boundary-sha>` and parse `<last-version>` from its message with `grep -oE "v[0-9]+\.[0-9]+\.[0-9]+"`.
+
+**Fallback 2 (neither tags nor markers — new repository):** use `v0.0.0` as baseline and suggest `v0.1.0`.
 
 **Step 1e — Pending-version awareness (Task mode only):**
 
@@ -184,7 +204,7 @@ rationale: "New features added (release agent), no breaking changes detected"
 **Output fields:**
 - `changes`: Complete list of changes since the last release boundary, one entry per PR or meaningful commit. Use conventional changelog types: `Added`, `Changed`, `Fixed`, `Removed`, `Deprecated`, `Security`. Each entry must be a self-contained description suitable for pasting directly into `CHANGELOG.md`. Include a `reference` (PR number or commit SHA) for traceability.
 - `severity`: MAJOR, MINOR, or PATCH
-- `latest_version`: Version extracted from the boundary release-marker commit (e.g., `v1.1.2`)
+- `latest_version`: Highest release version reachable from `origin/main`, from Step 1d's own lookup (e.g., `v1.1.2`) — not re-read from the boundary commit, which can name a lower version when tags land out of order
 - `suggested_version`: Next version following semver rules, adjusted past any pending-claimed collision in Task mode
 - `rationale`: Brief explanation of the severity assessment
 - `mode`: `batch` or `task` (Task mode also echoes `task_branch` and, if a collision was avoided, the claimed version(s) skipped)
@@ -196,8 +216,9 @@ rationale: "New features added (release agent), no breaking changes detected"
 - This skill only **analyzes and suggests** - it does not modify any files
 - The suggested version is a recommendation that must be approved before use
 - Session history files (`.smaqit/history/`) are optional - if they don't exist, rely on git log
-- **Exact release-marker commits are the canonical boundary** — local releases use `"Release vX.Y.Z"` and PR-based releases use `"Prepare release vX.Y.Z"`; use the most recent marker of either form in preference to git tags or PR timestamps
-- **Shallow clones:** always deepen before querying git log; the boundary-commit approach still works as long as the previous release-marker commit is reachable
+- **Release tags are the canonical boundary** — every release is tagged `vX.Y.Z` regardless of which flow produced it, so tags are the only marker that spans both the batch and PR-gated eras. Marker commits (`"Release vX.Y.Z"`, `"Prepare release vX.Y.Z"`) are a fallback for tagless repositories only: under the PR-gated model that string exists solely as a PR title, and the merge commit GitHub writes (`Merge pull request #NNN from …`) matches no marker pattern
+- **`<boundary-sha>` and `<last-version>` are separate lookups** (Steps 1c and 1d) — topologically latest reachable tag for the delta, highest-numbered reachable tag for the version baseline. They diverge whenever tags land out of numeric order, which the per-task release model produces by design
+- **Shallow clones:** always deepen *and* `git fetch --tags --force` before resolving; the tag-based boundary depends on tags being present locally, which is precisely what the fetch guarantees
 - **Always fetch `origin/main` immediately before searching, never reuse an earlier fetch in the same session** — the boundary and pending-version checks (Step 1a, 1c, 1e) must reflect the remote's current tip, not a cached local ref, so two tasks completing minutes apart never compute the same version
 - Focus on user-facing changes; internal implementation details should not drive severity
 - When in doubt between severities, prefer conservative (e.g., MINOR over MAJOR)

--- a/skills/smaqit.release-prepare-files/SKILL.md
+++ b/skills/smaqit.release-prepare-files/SKILL.md
@@ -2,7 +2,7 @@
 name: smaqit.release-prepare-files
 description: Validate git state and prepare all files (CHANGELOG.md, version files) for release
 metadata:
-  version: "0.7.0"
+  version: "0.8.0"
 ---
 
 # Release Prepare Files
@@ -89,24 +89,38 @@ grep "## \\[X.Y.Z\\]" CHANGELOG.md
 
 **A. Collect all changes since last release (reconciliation source):**
 
-The release workflows create exact release-marker commits in two compatible forms: `"Release vX.Y.Z"` for local releases and `"Prepare release vX.Y.Z"` for PR-based releases. Use the most recent marker of either form as the **authoritative boundary** — it is more reliable than git tags (absent in shallow clones) and more precise than PR merge timestamps (which can be incorrectly ordered).
+**Every release is tagged `vX.Y.Z`**, whichever flow produced it, so tags are the **authoritative boundary** — see `smaqit.release-analysis`' Step 1 for the full rationale. Release-marker commits (`"Release vX.Y.Z"`, `"Prepare release vX.Y.Z"`) are a fallback only: under the PR-gated per-task release model that string exists solely as a PR title, so in a repository that has released through both eras the marker-commit history silently stops at its last pre-PR-gated release.
 
-**Step 2A-1 — Deepen the clone so the boundary commit is reachable:**
+**Step 2A-1 — Deepen the clone and fetch tags so the boundary is reachable:**
 ```bash
+git fetch origin main 2>/dev/null || true
+git fetch --tags --force --quiet 2>/dev/null || true
 git fetch --unshallow 2>/dev/null || git fetch --depth=2147483647 2>/dev/null || true
 ```
 
 **Step 2A-2 — Find the boundary SHA:**
-```bash
-# List all exact local and PR release markers, most recent first
-git log --format="%H %s" | grep -iE "^[0-9a-f]+ (Prepare release|Release) v[0-9]+\.[0-9]+\.[0-9]+$"
-```
-- **If HEAD is a release-marker commit** (agent is already on a prepared release commit) — take the **second** entry.
-- **Otherwise** — take the **first** entry.
 
-Store as `<boundary-sha>`. Confirm:
+Resolve against `origin/main` rather than local `HEAD`, matching `release-analysis`' staleness hardening — a local `HEAD` can lag the remote tip and yield a boundary that silently re-includes already-released work:
+```bash
+# Most recent release tag reachable from the fetched remote tip
+git describe --tags --abbrev=0 origin/main
+```
+- **If the tip is itself tagged** (agent is already on a prepared release commit) — take the **next-older** tag: `git describe --tags --abbrev=0 "$(git describe --tags --abbrev=0 origin/main)^"`.
+- **Otherwise** — use the tag above.
+
+Dereference it to a commit and store as `<boundary-sha>`:
+```bash
+git rev-list -n1 "<tag>"
+```
+
+Confirm:
 ```bash
 git log -1 --oneline "<boundary-sha>"
+```
+
+**Fallback (no tags exist):** fall back to the marker-commit search, taking the second entry when `HEAD` is itself a marker commit and the first otherwise:
+```bash
+git log origin/main --format="%H %s" | grep -iE "^[0-9a-f]+ (Prepare release|Release) v[0-9]+\.[0-9]+\.[0-9]+$"
 ```
 
 **Step 2A-3 — Collect commits after the boundary:**
@@ -125,12 +139,7 @@ git log "<boundary-sha>..HEAD" --no-merges --pretty=format:"%h %s"
 
 The remaining commits are the real changelog delta.
 
-**Fallback (no release-marker commits found):** use git tags:
-```bash
-git fetch --tags --quiet 2>/dev/null || true
-git tag --sort=-v:refname | head -1
-# Then: git log <last-tag>..HEAD --merges/--no-merges
-```
+**Fallback (neither tags nor release-marker commits — new repository):** treat the full history as the delta and use `v0.0.0` as the baseline.
 
 **B. Reconcile `[Unreleased]` section with collected changes:**
 
@@ -274,6 +283,6 @@ version_synced: true
 - Version files are optional - CHANGELOG.md is the only required file
 - Keep a Changelog format uses version WITHOUT 'v' prefix in headers (e.g., `## [0.3.0]`), but git tags use 'v' prefix (e.g., `v0.3.0`)
 - For PR-based releases, validation rules are slightly relaxed (feature branch OK)
-- **Exact release-marker commits are the canonical boundary** — always deepen the clone first; locate the most recent local `"Release vX.Y.Z"` or PR `"Prepare release vX.Y.Z"` marker and use its SHA as the lower bound for `git log`
+- **Release tags are the canonical boundary** — always deepen the clone and `git fetch --tags --force` first, then resolve the most recent tag reachable from `origin/main` (`git describe --tags --abbrev=0`) and dereference it with `git rev-list -n1` for the lower bound. Marker commits are a fallback for tagless repositories only; under the PR-gated release model no marker commit is ever written
 - **Reconciliation is mandatory:** always cross-check `[Unreleased]` against the commit delta before promoting; the `[Unreleased]` section is often incomplete or empty
 - Uncommitted changes in working tree are acceptable - `release-git-local` handles commit grouping

--- a/tests/skills/test-release-analysis-boundary-detection.sh
+++ b/tests/skills/test-release-analysis-boundary-detection.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Hermetic checks for release-boundary detection: a reference implementation of
+# smaqit.release-analysis' Step 1c/1d tag lookups, exercised against fixture
+# repositories that reproduce real mixed-era release history, plus contract
+# assertions that both boundary-consuming skills document the tag-primary
+# algorithm and its fallbacks.
+#
+# The bug this guards against: under the PR-gated per-task release model, the
+# string "Prepare release vX.Y.Z" only ever exists as a PR *title*. The merge
+# commit GitHub writes reads "Merge pull request #NNN from owner/branch", which
+# the old marker regex never matches — so boundary detection silently skipped
+# back to the last pre-PR-gated release.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/smaqit-release-boundary.XXXXXX")"
+
+cleanup() {
+  rm -rf "$FIXTURE_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "[FAIL] $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1" pattern="$2" message="$3"
+  rg -q --fixed-strings -- "$pattern" "$file" || fail "$message — expected [$pattern] in $file"
+}
+
+assert_eq() {
+  local actual="$1" expected="$2" message="$3"
+  [ "$actual" = "$expected" ] || fail "$message — expected [$expected], got [$actual]"
+}
+
+assert_ne() {
+  local a="$1" b="$2" message="$3"
+  [ "$a" != "$b" ] || fail "$message — both were [$a]"
+}
+
+# --- Fixture helpers -------------------------------------------------------
+
+git_init_fixture() {
+  local repo="$1"
+  mkdir -p "$repo"
+  git -C "$repo" init -q -b main
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "Fixture"
+  git -C "$repo" config commit.gpgsign false
+  git -C "$repo" config tag.gpgsign false
+}
+
+commit() {
+  local repo="$1" message="$2"
+  echo "$RANDOM-$message" >> "$repo/log.txt"
+  git -C "$repo" add -A
+  git -C "$repo" commit -q -m "$message"
+}
+
+# Simulates a merged PR: a side branch merged with --no-ff carrying GitHub's
+# own default merge message. Deliberately produces NO release-marker commit.
+merge_pr() {
+  local repo="$1" number="$2" branch="$3" work="$4"
+  git -C "$repo" checkout -q -b "$branch"
+  commit "$repo" "$work"
+  git -C "$repo" checkout -q main
+  git -C "$repo" merge -q --no-ff -m "Merge pull request #${number} from owner/${branch}" "$branch"
+}
+
+# --- Reference implementation of the FIXED Step 1c / 1d --------------------
+
+boundary_tag() { git -C "$1" describe --tags --abbrev=0 "$2" 2>/dev/null; }
+boundary_sha() { git -C "$1" rev-list -n1 "$2"; }
+last_version() { git -C "$1" tag --merged "$2" --sort=-v:refname | head -1; }
+
+# The pre-fix behaviour, retained so the test proves the bug rather than
+# merely asserting the new code agrees with itself.
+legacy_boundary_sha() {
+  git -C "$1" log "$2" --format="%H %s" \
+    | grep -iE "^[0-9a-f]+ (Prepare release|Release) v[0-9]+\.[0-9]+\.[0-9]+$" \
+    | head -1 | cut -d' ' -f1
+}
+
+# --- Fixture 1: mixed-era history -----------------------------------------
+# Batch-era releases (real marker commits) followed by a PR-gated release
+# (merge commit only, no marker) — exactly this repository's own shape.
+
+MIXED="$FIXTURE_ROOT/mixed-era"
+git_init_fixture "$MIXED"
+
+commit "$MIXED" "initial commit"
+commit "$MIXED" "feat: alpha"
+commit "$MIXED" "Release v1.0.0"                       # batch-era local release
+git -C "$MIXED" tag -a v1.0.0 -m "Release v1.0.0"
+
+commit "$MIXED" "feat: beta"
+commit "$MIXED" "Prepare release v1.1.0"               # batch-era PR release
+merge_pr "$MIXED" 5 "release/v1.1.0" "chore: bump"
+git -C "$MIXED" tag -a v1.1.0 -m "Release v1.1.0"      # tag lands on the merge
+
+commit "$MIXED" "feat: gamma"
+merge_pr "$MIXED" 10 "task/030-widget" "feat: widget"  # PR-GATED: no marker
+PR_GATED_MERGE="$(git -C "$MIXED" rev-parse HEAD)"
+git -C "$MIXED" tag -a v1.2.0 -m "Release v1.2.0"
+
+commit "$MIXED" "feat: delta"                          # unreleased work
+
+fixed_tag="$(boundary_tag "$MIXED" HEAD)"
+fixed_sha="$(boundary_sha "$MIXED" "$fixed_tag")"
+legacy_sha="$(legacy_boundary_sha "$MIXED" HEAD)"
+
+assert_eq "$fixed_tag" "v1.2.0" "tag lookup must find the PR-gated release, not the last marker commit"
+assert_eq "$fixed_sha" "$PR_GATED_MERGE" "boundary must dereference to the PR-gated merge commit"
+assert_eq "$(last_version "$MIXED" HEAD)" "v1.2.0" "last-version must be the highest reachable tag"
+
+# Prove the bug actually existed: the old regex resolves somewhere else entirely.
+assert_ne "$legacy_sha" "$fixed_sha" "regression guard: old marker regex must NOT agree with the tag lookup here"
+legacy_subject="$(git -C "$MIXED" log -1 --format=%s "$legacy_sha")"
+assert_eq "$legacy_subject" "Prepare release v1.1.0" "old regex is expected to skip back to the last marker commit"
+
+echo "[PASS] mixed-era history: tag lookup finds the PR-gated release the marker regex skips"
+
+# --- Fixture 1b: batch mode with an already-tagged tip ---------------------
+# When the tip is itself the release, that tag must not also be the lower bound.
+
+tip_tag="$(boundary_tag "$MIXED" "$PR_GATED_MERGE")"
+assert_eq "$tip_tag" "v1.2.0" "a tagged tip describes as its own tag"
+prev_tag="$(boundary_tag "$MIXED" "${PR_GATED_MERGE}^")"
+assert_eq "$prev_tag" "v1.1.0" "stepping back one commit from a tagged tip yields the previous release"
+
+echo "[PASS] batch mode: a tagged tip steps back to the previous release tag"
+
+# --- Fixture 2: out-of-order tags -----------------------------------------
+# Per-task releases claim versions before merging, and PRs merge in review
+# order, not version order — so boundary (topological) and version baseline
+# (numeric) legitimately disagree.
+
+OOO="$FIXTURE_ROOT/out-of-order"
+git_init_fixture "$OOO"
+
+commit "$OOO" "initial commit"
+git -C "$OOO" tag -a v2.0.0 -m "Release v2.0.0"
+
+merge_pr "$OOO" 200 "task/200-minor" "feat: minor feature"
+git -C "$OOO" tag -a v2.1.0 -m "Release v2.1.0"        # MINOR merges first
+
+merge_pr "$OOO" 201 "task/201-patch" "fix: patch"
+LATER_MERGE="$(git -C "$OOO" rev-parse HEAD)"
+git -C "$OOO" tag -a v2.0.1 -m "Release v2.0.1"        # PATCH merges second
+
+commit "$OOO" "feat: subsequent work"
+
+ooo_boundary_tag="$(boundary_tag "$OOO" HEAD)"
+ooo_last_version="$(last_version "$OOO" HEAD)"
+
+assert_eq "$ooo_boundary_tag" "v2.0.1" "boundary must be the topologically latest tag"
+assert_eq "$(boundary_sha "$OOO" "$ooo_boundary_tag")" "$LATER_MERGE" "boundary dereferences to the last-merged release"
+assert_eq "$ooo_last_version" "v2.1.0" "last-version must be the highest-numbered tag, not the nearest one"
+assert_ne "$ooo_boundary_tag" "$ooo_last_version" "the two lookups must be independent — this is the whole reason they are separate"
+
+# Conflating them is what regresses the version baseline below a shipped release.
+[ "$ooo_boundary_tag" = "v2.0.1" ] && [ "$ooo_last_version" = "v2.1.0" ] \
+  || fail "out-of-order divergence not reproduced"
+
+echo "[PASS] out-of-order tags: boundary and version baseline resolve independently"
+
+# --- Fixture 3: tagless repository falls back to marker commits ------------
+
+TAGLESS="$FIXTURE_ROOT/tagless"
+git_init_fixture "$TAGLESS"
+
+commit "$TAGLESS" "initial commit"
+commit "$TAGLESS" "Release v0.1.0"
+TAGLESS_MARKER="$(git -C "$TAGLESS" rev-parse HEAD)"
+commit "$TAGLESS" "feat: post-release work"
+
+[ -z "$(boundary_tag "$TAGLESS" HEAD)" ] || fail "tagless fixture unexpectedly resolved a tag"
+assert_eq "$(legacy_boundary_sha "$TAGLESS" HEAD)" "$TAGLESS_MARKER" "tagless repo must fall back to the marker commit"
+
+echo "[PASS] tagless repository falls back to marker-commit detection"
+
+# --- Contract assertions: the skills document the fixed algorithm ----------
+
+RELEASE_ANALYSIS="$SOURCE_ROOT/skills/smaqit.release-analysis/SKILL.md"
+RELEASE_PREPARE="$SOURCE_ROOT/skills/smaqit.release-prepare-files/SKILL.md"
+
+assert_contains "$RELEASE_ANALYSIS" 'git fetch --tags --force' "release-analysis fetches tags before resolving the boundary"
+assert_contains "$RELEASE_ANALYSIS" 'git describe --tags --abbrev=0 origin/main' "release-analysis resolves the boundary from tags on origin/main"
+assert_contains "$RELEASE_ANALYSIS" 'git rev-list -n1' "release-analysis dereferences the tag to a commit"
+assert_contains "$RELEASE_ANALYSIS" 'git tag --merged origin/main --sort=-v:refname' "release-analysis derives last-version from the highest reachable tag"
+assert_contains "$RELEASE_ANALYSIS" 'separate lookup from Step 1c' "release-analysis states that boundary and last-version are separate lookups"
+assert_contains "$RELEASE_ANALYSIS" 'Fallback 1' "release-analysis retains a marker-commit fallback for tagless repositories"
+assert_contains "$RELEASE_ANALYSIS" '(Prepare release|Release) v[0-9]+\.[0-9]+\.[0-9]+$' "release-analysis keeps the marker regex available as a fallback"
+
+assert_contains "$RELEASE_PREPARE" 'git fetch --tags --force' "release-prepare-files fetches tags before resolving the boundary"
+assert_contains "$RELEASE_PREPARE" 'git describe --tags --abbrev=0 origin/main' "release-prepare-files resolves the boundary from tags on origin/main"
+assert_contains "$RELEASE_PREPARE" 'git rev-list -n1' "release-prepare-files dereferences the tag to a commit"
+
+echo "[PASS] release-boundary detection contract"


### PR DESCRIPTION
Fixes release-boundary detection for repositories that release through the PR-gated per-task flow (task 027+).

## Problem

`release-analysis` Step 1c located the release boundary by searching for a commit whose message exactly matches `Prepare release vX.Y.Z` or `Release vX.Y.Z`. That worked for the batch-release flow, which really did create such a commit. Under the PR-gated model that string only ever exists as a **PR title** — the merge commit GitHub writes reads `Merge pull request #NNN from owner/branch`, which the regex never matches.

The boundary therefore silently skipped back to the last pre-PR-gated release. On this repository the most recent match was `fb133be Release v1.17.1`, meaning every task completed since then computed its changelog delta against a boundary **three releases stale** (v1.17.2, v1.18.0, v2.0.0 were all invisible). Task 030 hit this live and had to override the boundary by hand.

`release-prepare-files` Step 2A-2 carried the identical regex, and additionally searched local `HEAD` rather than `origin/main`.

## Fix

- **Tags become the authoritative boundary.** Every release is tagged `vX.Y.Z` whichever flow produced it, so tags are the only marker spanning both eras. `git describe --tags --abbrev=0 origin/main` → `git rev-list -n1`. The marker regex is retained as a fallback for tagless repositories, with `v0.0.0`/`v0.1.0` as a final fallback for new ones.
- **`<last-version>` becomes an independent lookup** (`git tag --merged origin/main --sort=-v:refname | head -1`) rather than a re-read of the boundary commit. The two answer different questions and legitimately diverge: per-task PRs merge in review order, not version order, so tags land out of numeric sequence by design. Conflating them lets the next suggestion regress *below* an already-released version — which Step 1e cannot catch, because by then the collision is released rather than pending.
- **Tags are fetched explicitly** (`git fetch --tags --force`), which is what makes the tag approach safe in the shallow clones that originally motivated preferring commits.
- **`release-prepare-files` gets the same treatment**, and is realigned from local `HEAD` to `origin/main`.

Both skills' Important Notes claimed marker commits were "more reliable than git tags" — now inverted and corrected.

## Verification

Replaying task 030's completion point against real history:

```
old regex → fb133be  Release v1.17.1     ← the wrong boundary that forced the manual override
fixed     → v1.17.2  219d67c             ← correct
```

New `tests/skills/test-release-analysis-boundary-detection.sh` covers three fixture repositories — mixed-era history, out-of-order tags, and a tagless repo — plus contract assertions against both skills. It asserts the *old* regex **disagrees** with the tag lookup on mixed-era history, so it proves the bug rather than merely agreeing with the new implementation. Confirmed to fail when run against the pre-fix skills.

`make test` and `make smoke-test` both pass.

This PR itself exercises the fix: `v2.0.1` is already claimed by PR #128, so this release takes `v2.0.2`. If #128 merges after this one, the resulting tags land out of numeric order — precisely the case the split lookup now handles.

## Post-Merge Automation

When this PR is merged to `main`, the post-merge workflow will automatically:

✅ Create git tag `v2.0.2`
✅ Publish GitHub Release with the changelog excerpt

Workflow: `.github/workflows/post-merge-release.yml`
