### PR TITLE
Prepare release v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.3] - 2026-08-18
+
 ### Fixed
-- **`.code-workspace` regeneration no longer discards content it doesn't own** (pending v2.0.3 · PR #130) — `7_build_workspace.sh` now preserves any manually-added folder (e.g. a sibling repo) and any custom `settings` key across every `task-start`/`task-complete` regeneration, and the workspace file is excluded from task-worktree sparse checkouts since it's only ever written from the primary checkout.
+- **`.code-workspace` regeneration no longer discards content it doesn't own** — `7_build_workspace.sh` now preserves any manually-added folder (e.g. a sibling repo) and any custom `settings` key across every `task-start`/`task-complete` regeneration, and the workspace file is excluded from task-worktree sparse checkouts since it's only ever written from the primary checkout.
 
 ## [2.0.1] - 2026-08-16
 

--- a/skills/smaqit.utils.worktree/SKILL.md
+++ b/skills/smaqit.utils.worktree/SKILL.md
@@ -2,7 +2,7 @@
 name: smaqit.utils.worktree
 description: "Sync Git worktrees and update the VS Code multi-root workspace, or set up worktrees for task branches. For interactive sync, presents local and remote branches and asks which branches to sync. Then creates missing sibling worktrees, detects and removes safe orphans, and keeps the project workspace in sync. Also migrates VS Code chat sessions when switching from a single-folder project to the generated multi-root workspace. Use after task branch creation, task completion, workspace migration, or when worktree folders are missing from VS Code Explorer. Triggers: `worktree.sync`, `worktree.migrate-sessions`."
 metadata:
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # smaqit Utils: Git Worktree Manager
@@ -134,9 +134,9 @@ Run the workspace build script. It reads the current Git worktree state directly
 bash [SMAQIT_SKILLS_DIR]/smaqit.utils.worktree/scripts/7_build_workspace.sh
 ```
 
-The script is self-contained — it re-enumerates worktrees from `git worktree list` on every invocation, so the workspace file always reflects actual disk state regardless of earlier steps. Idempotent: same Git state always produces the same output.
+The script is self-contained — it re-enumerates worktrees from `git worktree list` on every invocation, so the `main` + worktree portion of the workspace file always reflects actual disk state regardless of earlier steps. It reads the existing file first and preserves anything it doesn't own: a `folders` entry whose path isn't `.` or a `../<project>-wt-*` worktree slug (e.g. a manually-added sibling repo), and any `settings` key beyond the managed `files.exclude` block. Idempotent: same Git state plus the same foreign content always produces the same output.
 
-If there are no active worktrees, the folders array contains only `main`.
+If there are no active worktrees, the folders array contains only `main` plus any preserved foreign entries.
 
 ### 8. Write settings (omitted — merged into Step 7)
 
@@ -251,10 +251,10 @@ For a child task, none of this cleanup runs. Child completion records criteria, 
 5. **Orphan safety.** Double-check that the branch is confirmed gone from `git branch --list` before removing a worktree. Accidental removal causes data loss.
 6. **Full workflow is idempotent.** Running the skill multiple times with the same branch selection produces the same result — existing worktrees are skipped, orphans are cleaned, and the workspace file is regenerated from current state. No duplicate worktrees or stale entries.
 7. **Invocation behavior.** `task-start` supplies its branch automatically. Direct `worktree.sync` requires user selection before creating worktrees.
-8. **The workspace file is Git-committed.** Commit the updated workspace with other changes to keep it versioned.
+8. **The workspace file is Git-committed.** Commit the updated workspace with other changes to keep it versioned. Regeneration (Step 7) merges rather than overwrites: only the `main` + worktree folders and the `files.exclude` setting are managed and rebuilt from Git state on every run — any other folder or setting already in the file is read back and preserved.
 9. **VS Code must be reopened** with the root workspace file after it is created or updated for the new folder layout to appear.
 10. **Session migration when switching workspaces.** Switching to a multi-root workspace creates a new VS Code storage entry. Invoke `worktree.migrate-sessions` explicitly if existing chat sessions should be copied.
-11. **Generated mirrors and task state are excluded from task worktrees.** Sparse checkout excludes `.github/agents/`, `.github/skills/`, `.claude/agents/`, `.claude/commands/`, `.claude/skills/`, `.agents/skills/`, and `.codex/agents/` defensively, plus `.smaqit/tasks/` to keep task state single-sourced on primary. Under the default global install, a project has none of those agent/skill paths at all — they only exist for a project that ran `install --scope project`, this repository included, since it carries no committed dogfooding mirrors of its own. Project-owned paths such as `.github/workflows/` and the rest of `.smaqit/` remain available.
+11. **Generated mirrors, task state, and the workspace file are excluded from task worktrees.** Sparse checkout excludes `.github/agents/`, `.github/skills/`, `.claude/agents/`, `.claude/commands/`, `.claude/skills/`, `.agents/skills/`, and `.codex/agents/` defensively, plus `.smaqit/tasks/` to keep task state single-sourced on primary, plus the root `*.code-workspace` file itself — Step 7 always runs from the primary checkout (Gotcha #16), so a worktree never needs its own copy. Under the default global install, a project has none of those agent/skill paths at all — they only exist for a project that ran `install --scope project`, this repository included, since it carries no committed dogfooding mirrors of its own. Project-owned paths such as `.github/workflows/` and the rest of `.smaqit/` remain available.
 12. **Task branches modify canonical source, not generated mirrors.** Regenerate platform mirrors from canonical sources during the normal synchronization step.
 13. **Existing unregistered directories are preserved.** Report the conflict for user review; do not remove the directory automatically.
 14. **Parent tasks own Git resources.** A child task joins its active parent's registered branch/worktree and inherits its mode. Only a standalone or parent task can merge, remove a worktree, delete a branch, or rebuild the workspace.

--- a/skills/smaqit.utils.worktree/scripts/5_create_worktrees.sh
+++ b/skills/smaqit.utils.worktree/scripts/5_create_worktrees.sh
@@ -51,7 +51,9 @@ for branch in $(echo "$input_json" | jq -r 'keys[]'); do
     # exclusively on the primary checkout — see 9_resolve_task_lifecycle.sh —
     # so worktrees never carry a mutable copy that could diverge and conflict
     # on merge. `set` enables worktree-specific sparse config itself, so no
-    # separate init can leave a transient root-only checkout behind.
+    # separate init can leave a transient root-only checkout behind. The root
+    # `.code-workspace` file is excluded for the same reason — Step 7 always
+    # runs from the primary checkout, so a worktree never needs its own copy.
     if sparse_error="$(git -C "$wt_path" sparse-checkout set --no-cone \
       '/*' \
       '!.github/agents/' \
@@ -62,6 +64,7 @@ for branch in $(echo "$input_json" | jq -r 'keys[]'); do
       '!.agents/skills/' \
       '!.codex/agents/' \
       '!.smaqit/tasks/' \
+      '!/*.code-workspace' \
       2>&1)"; then
       created="$(echo "$created" | jq --arg b "$branch" --arg p "$wt_path" '. + {($b): $p}')"
     else

--- a/skills/smaqit.utils.worktree/scripts/7_build_workspace.sh
+++ b/skills/smaqit.utils.worktree/scripts/7_build_workspace.sh
@@ -5,6 +5,10 @@
 # Self-contained: reads current Git worktree state and writes or updates a root
 # `.code-workspace` file with `main` plus all active non-primary worktrees.
 # It always re-enumerates `git worktree list` so repeated runs are idempotent.
+# Any pre-existing `folders` entry this script doesn't own (not `.`, not a
+# `../<project>-wt-*` worktree slug) and any `settings` key beyond the managed
+# `files.exclude` block are read back from the existing file and preserved,
+# rather than being discarded on every regeneration.
 #
 # Usage: bash 7_build_workspace.sh
 # Output: path to the written workspace file.
@@ -12,6 +16,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+PROJECT_NAME="$(basename "$REPO_ROOT")"
 
 # Use an existing root workspace when present; otherwise derive its name from
 # the repository directory.
@@ -19,11 +24,11 @@ EXISTING_WORKSPACE="$(find "$REPO_ROOT" -maxdepth 1 -type f -name '*.code-worksp
 if [ -n "$EXISTING_WORKSPACE" ]; then
   WORKSPACE_FILE="$EXISTING_WORKSPACE"
 else
-  PROJECT_NAME="$(basename "$REPO_ROOT")"
   WORKSPACE_FILE="$REPO_ROOT/$PROJECT_NAME.code-workspace"
 fi
 
-# Build the folders array starting with the primary repository.
+# Build the managed folders array: the primary repository plus every active
+# worktree. This portion is always fully regenerated from Git state.
 folders='[{"name": "main", "path": "."}'
 while IFS= read -r line; do
   case "$line" in
@@ -42,11 +47,29 @@ while IFS= read -r line; do
 done < <(git -C "$REPO_ROOT" worktree list --porcelain)
 folders="$folders]"
 
-# Exclude build output only. Workspace settings apply to every root, so hiding
-# platform paths here would also hide them from the primary checkout and agents.
+# Read whatever the existing file already holds, so anything this script
+# doesn't own can be preserved. A first run (no existing file) has nothing to
+# preserve — jq's `//` defaults cover that case.
+if [ -f "$WORKSPACE_FILE" ]; then
+  existing_content="$(cat "$WORKSPACE_FILE")"
+else
+  existing_content='{}'
+fi
+
+# Preserve foreign folders (anything not `.` and not a managed worktree slug)
+# and any settings key beyond the managed files.exclude block. Exclude build
+# output only — workspace settings apply to every root, so hiding platform
+# paths here would also hide them from the primary checkout and agents.
 jq -n \
   --argjson folders "$folders" \
-  '{folders: $folders, settings: {"files.exclude": {"**/bin/**": true, "**/obj/**": true}}}' \
+  --argjson existing "$existing_content" \
+  --arg project "$PROJECT_NAME" \
+  '
+  ($existing.folders // []) as $existing_folders
+  | ($existing_folders | map(select((.path == "." or (.path | startswith("../" + $project + "-wt-"))) | not))) as $foreign_folders
+  | (($existing.settings // {}) * {"files.exclude": {"**/bin/**": true, "**/obj/**": true}}) as $merged_settings
+  | {folders: ($folders + $foreign_folders), settings: $merged_settings}
+  ' \
   > "$WORKSPACE_FILE"
 
 echo "$WORKSPACE_FILE"

--- a/tests/skills/test-worktree-layout.sh
+++ b/tests/skills/test-worktree-layout.sh
@@ -53,6 +53,11 @@ create_fixture_repo() {
     "$repo/.agents/skills/generated.md" \
     "$repo/.codex/agents/generated.toml" \
     "$repo/project.txt"
+  # A tracked placeholder workspace file, committed before any worktree is
+  # created, so a regression that stops excluding it from sparse checkout
+  # would actually show up in the new worktree's checkout.
+  echo '{"folders": [{"name": "main", "path": "."}], "settings": {}}' \
+    > "$repo/$(basename "$repo").code-workspace"
   git -C "$repo" init -q -b main
   git -C "$repo" config user.email test@example.invalid
   git -C "$repo" config user.name test
@@ -91,6 +96,7 @@ assert_missing "$fixture_worktree/.claude/commands"
 assert_missing "$fixture_worktree/.claude/skills"
 assert_missing "$fixture_worktree/.agents/skills"
 assert_missing "$fixture_worktree/.codex/agents"
+assert_missing "$fixture_worktree/repo.code-workspace"
 
 (cd "$fixture_repo" && bash "$global_scripts/7_build_workspace.sh") >/dev/null
 workspace_file="$fixture_repo/repo.code-workspace"
@@ -99,6 +105,26 @@ jq -e '.settings["files.exclude"] == {"**/bin/**": true, "**/obj/**": true}' "$w
   || fail "Workspace hides platform paths"
 jq -e '.folders | length == 2 and .[0].name == "main" and .[1].name == "task/019-layout"' "$workspace_file" >/dev/null \
   || fail "Workspace folders do not reflect the created worktree"
+
+# Inject content this script doesn't own — a manually-added sibling repo
+# folder and a custom setting — then remove the worktree and rebuild. Both
+# must survive; only the removed worktree's own folder entry should drop.
+jq '.folders += [{"name": "local-llm", "path": "../local-llm"}] | .settings["myCustomSetting"] = true' \
+  "$workspace_file" > "$workspace_file.tmp"
+mv "$workspace_file.tmp" "$workspace_file"
+
+git -C "$fixture_repo" worktree remove "$fixture_worktree"
+git -C "$fixture_repo" branch -D "$fixture_branch" >/dev/null
+
+(cd "$fixture_repo" && bash "$global_scripts/7_build_workspace.sh") >/dev/null
+jq -e '.folders | length == 2
+    and (map(.name) | index("main") != null)
+    and (map(.name) | index("local-llm") != null)
+    and (map(.name) | index("task/019-layout") | not)' "$workspace_file" >/dev/null \
+  || fail "Foreign folder did not survive workspace regeneration, or the removed worktree's entry lingered"
+jq -e '.settings["myCustomSetting"] == true
+    and .settings["files.exclude"] == {"**/bin/**": true, "**/obj/**": true}' "$workspace_file" >/dev/null \
+  || fail "Foreign setting did not survive workspace regeneration"
 
 failure_repo="$fixture_root/failure-repo"
 failure_branch='task/019-sparse-failure'


### PR DESCRIPTION
## Summary

Fixes `.code-workspace` regeneration in `smaqit.utils.worktree` silently discarding content it doesn't own.

- `7_build_workspace.sh` now reads the existing workspace file before writing, preserves any `folders` entry that isn't `.` or a `../<project>-wt-*` worktree slug (e.g. a manually-added sibling repo), and deep-merges `settings` instead of overwriting it wholesale.
- `5_create_worktrees.sh` now excludes the root `*.code-workspace` file from task-worktree sparse checkouts, since it's only ever written from the primary checkout.
- `tests/skills/test-worktree-layout.sh` extended with regression coverage for both fixes — verified independently to fail against the pre-fix scripts.
- `SKILL.md` updated (Step 7, Gotchas #8/#11); skill version bumped `1.4.0` → `1.5.0`.

Reported live: a manually-added sibling repo folder (`local-llm`) disappeared from a shared workspace file after a `task-start`/`task-complete` cycle, reproduced when a concurrent session's cleanup for tasks 031/033 dropped both worktree entries in commit `7dd05b5`.

## Post-Merge Automation

This PR title follows the `Prepare release vX.Y.Z` convention required by `post-merge-release.yml` — merging this PR tags `v2.0.3` and publishes the matching GitHub Release automatically.

## Test plan
- [x] `make test-worktree-layout`
- [x] `make test`
- [x] `make smoke-test`